### PR TITLE
Upgrade dbt-utils v0.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             . venv/bin/activate
 
             pip install --upgrade pip setuptools
-            pip install dbt --upgrade
+            pip install --pre dbt --upgrade
 
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
-# dbt-codegen v0.4.0 (unreleased)
+# dbt-codegen v0.4.0
+
+## Breaking changes
+- Requires `dbt>=0.20.0` and `dbt-utils>=0.7.0`
+- Depends on `dbt-labs/dbt_utils` (instead of `fishtown-analytics/dbt_utils`)
+
+## Features
+- Add optional `leading_commas` arg to `generate_base_model` (#41 @jaypeedevlin)
+- Add optional `include_descriptions` arg to `generate_source` (#40 @djbelknapdbs)
+
 ## Fixes
 - In the `generate_source` macro, use `dbt_utils.get_relations_by_pattern` instead of `get_relations_by_prefix`, since the latter will be deprecated in the future (#42)
 
-## Features
-- Add optional leading_commas arg to generate_base_model (#41 @jaypeedevlin)
-
-## Other
+## Under the hood
+- Use new adapter.dispatch syntax (#44)
 
 # dbt-codegen v0.3.2
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Macros that generate dbt code, and log it to the command line.
 
 # Installation instructions
 New to dbt packages? Read more about them [here](https://docs.getdbt.com/docs/building-a-dbt-project/package-management/).
-1. Include this package in your `packages.yml` file — check [here](https://hub.getdbt.com/fishtown-analytics/codegen/latest/) for the latest version number.
+1. Include this package in your `packages.yml` file — check [here](https://hub.getdbt.com/dbt-labs/codegen/latest/) for the latest version number.
 2. Run `dbt deps` to install the package.
 
 # Macros

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'codegen'
-version: '1.0'
+version: '0.4.0'
 
 require-dbt-version: ">=0.18.0"
 config-version: 2

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - package: fishtown-analytics/dbt_utils
+  - package: dbt-labs/dbt_utils
     version: [">=0.6.2", "<0.8.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: [">=0.6.2", "<0.7.0"]
+    version: [">=0.6.2", "<0.8.0"]


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [x] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation

Upgrade dbt-utils upper bound. I don't believe this package is affected by any breaking changes in either dbt v0.20 or dbt-utils 0.7

Update: change dependency on `fishtown-analytics/dbt_utils` to `dbt-labs/dbt_utils`.

## Checklist
- [ ] I have verified that these changes work locally
- ~I have updated the README.md (if applicable)~
- ~I have added tests & descriptions to my models (and macros if applicable)~
- [ ] I have added an entry to CHANGELOG.md
