### PR TITLE
New functionality - Retrieve the description for identical column names from upstream models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
             dbt --warn-error deps --target postgres
             dbt --warn-error run-operation create_source_table --target postgres
             dbt --warn-error seed --target postgres --full-refresh
+            dbt --warn-error run --target postgres
             dbt --warn-error test --target postgres
 
       - run:
@@ -55,6 +56,7 @@ jobs:
             dbt --warn-error deps --target redshift
             dbt --warn-error run-operation create_source_table --target redshift
             dbt --warn-error seed --target redshift --full-refresh
+            dbt --warn-error run --target redshift
             dbt --warn-error test --target redshift
 
       - run:
@@ -66,6 +68,7 @@ jobs:
             dbt --warn-error deps --target snowflake
             dbt --warn-error run-operation create_source_table --target snowflake
             dbt --warn-error seed --target snowflake --full-refresh
+            dbt --warn-error run --target snowflake
             dbt --warn-error test --target snowflake
 
       - run:
@@ -80,6 +83,7 @@ jobs:
             dbt --warn-error deps --target bigquery
             dbt --warn-error run-operation create_source_table --target bigquery
             dbt --warn-error seed --target bigquery --full-refresh
+            dbt --warn-error run --target bigquery
             dbt --warn-error test --target bigquery
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
 target/
 dbt_modules/
+dbt_packages/
 logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+## New features
+- Add support for importing descriptions from columns with the same names in upstream models. It is available by setting the parameter `upstream_descriptions` to `True` in `generate_model_yaml` ([#61](https://github.com/dbt-labs/dbt-codegen/pull/61))
+
 # dbt-codegen v0.6.0
 
 This release creates breaking changes to the `generate_source.sql` macro.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ schema.yml file.
 
 ### Arguments:
 * `model_name` (required): The model you wish to generate YAML for.
+* `upstream_descriptions` (optional, default=False): Whether you want to include descriptions for identical column names from upstream models.
 
 ### Usage:
 1. Create a model.

--- a/integration_tests/models/child_model.sql
+++ b/integration_tests/models/child_model.sql
@@ -1,0 +1,3 @@
+select 
+    * 
+from {{ ref('model_data_a') }}

--- a/integration_tests/models/model_data_a.sql
+++ b/integration_tests/models/model_data_a.sql
@@ -1,0 +1,3 @@
+select 
+    * 
+from {{ ref('data__a_relation') }}

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -1,0 +1,7 @@
+version: 2
+
+models:
+  - name: model_data_a
+    columns:
+      - name: col_a
+        description: description column a

--- a/integration_tests/tests/test_generate_model_yaml_upstream_descriptions.sql
+++ b/integration_tests/tests/test_generate_model_yaml_upstream_descriptions.sql
@@ -1,0 +1,22 @@
+{% set actual_model_yaml = codegen.generate_model_yaml(
+    model_name='child_model',
+    upstream_descriptions=True
+  )
+%}
+
+{% set expected_model_yaml %}
+version: 2
+
+models:
+  - name: child_model
+    description: ""
+    columns:
+      - name: col_a
+        description: "description column a"
+
+      - name: col_b
+        description: ""
+
+{% endset %}
+
+{{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -1,6 +1,7 @@
-{% macro generate_model_yaml(model_name) %}
+{% macro generate_model_yaml(model_name, upstream_descriptions=False) %}
 
 {% set model_yaml=[] %}
+{% set column_desc_dict =  codegen.build_dict_column_descriptions(model_name) if upstream_descriptions else {} %}
 
 {% do model_yaml.append('version: 2') %}
 {% do model_yaml.append('') %}
@@ -14,7 +15,7 @@
 
 {% for column in columns %}
     {% do model_yaml.append('      - name: ' ~ column.name | lower ) %}
-    {% do model_yaml.append('        description: ""') %}
+    {% do model_yaml.append('        description: "' ~ column_desc_dict.get(column.name | lower,'') ~ '"') %}
     {% do model_yaml.append('') %}
 {% endfor %}
 

--- a/macros/helpers/helpers.sql
+++ b/macros/helpers/helpers.sql
@@ -1,0 +1,29 @@
+{# retrieve directly upstream models from a given model #}
+{% macro get_model_dependencies(model_name) %}
+    {% for node in graph.nodes.values() | selectattr('name', "equalto", model_name) %}
+        {{ return(node.depends_on.nodes) }}
+    {% endfor %}
+{% endmacro %}
+
+
+{# add to an input dictionnary entries containing all the column descriptions of a given model #}
+{% macro add_model_column_descriptions_to_dict(model_name,dict_with_descriptions={}) %}
+    {% for node in graph.nodes.values() | selectattr('name', "equalto", model_name) %}
+        {% for col_name, col_values in node.columns.items() %}
+            {% do dict_with_descriptions.update( {col_name: col_values.description} ) %}
+        {% endfor %}
+    {% endfor %}
+    {{ return(dict_with_descriptions) }}
+{% endmacro %}
+
+{# build a global dictionnary looping through all the direct parents models #}
+{# if the same column name exists with different descriptions it is overwritten at each loop #}
+{% macro build_dict_column_descriptions(model_name) %}
+    {% if execute %}
+        {% set glob_dict = {} %}
+        {% for full_model in codegen.get_model_dependencies(model_name) %}
+            {% do codegen.add_model_column_descriptions_to_dict(full_model.split('.')[-1],glob_dict) %}
+        {% endfor %}
+        {{ return(glob_dict) }}
+    {% endif %}
+{% endmacro %}

--- a/macros/helpers/helpers.sql
+++ b/macros/helpers/helpers.sql
@@ -1,4 +1,4 @@
-{# retrieve directly upstream models from a given model #}
+{# retrieve models directly upstream from a given model #}
 {% macro get_model_dependencies(model_name) %}
     {% for node in graph.nodes.values() | selectattr('name', "equalto", model_name) %}
         {{ return(node.depends_on.nodes) }}
@@ -6,7 +6,7 @@
 {% endmacro %}
 
 
-{# add to an input dictionnary entries containing all the column descriptions of a given model #}
+{# add to an input dictionary entries containing all the column descriptions of a given model #}
 {% macro add_model_column_descriptions_to_dict(model_name,dict_with_descriptions={}) %}
     {% for node in graph.nodes.values() | selectattr('name', "equalto", model_name) %}
         {% for col_name, col_values in node.columns.items() %}
@@ -16,7 +16,7 @@
     {{ return(dict_with_descriptions) }}
 {% endmacro %}
 
-{# build a global dictionnary looping through all the direct parents models #}
+{# build a global dictionary looping through all the direct parents models #}
 {# if the same column name exists with different descriptions it is overwritten at each loop #}
 {% macro build_dict_column_descriptions(model_name) %}
     {% if execute %}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
When using the macro `generate_model_yaml` it can be cumbersome to have to copy/paste the description of the columns from the upstream models, especially when many models are joined together.

The new feature accessible via the flag `upstream_descriptions=True` (defaulted to False) parses the Jinja graph to retrieve existing descriptions in parent models.

An example of output is the following, when the upstream model has an existing description of `description column a`:
![image](https://user-images.githubusercontent.com/8754100/160831041-41b37910-0a24-4c50-ab98-01afc33342c7.png)

I am not too sure where I should add the entry in `CHANGELOG.md`

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
