### PR TITLE
Added case_sensitive_cols argument to generate_base_model macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ model.
 * `source_name` (required): The source you wish to generate base model SQL for.
 * `table_name` (required): The source table you wish to generate base model SQL for.
 * `leading_commas` (optional, default=False): Whether you want your commas to be leading (vs trailing).
-* `case_sensitive_cols ` (optional, default=False): Whether your source table has case sensitive column names.
+* `case_sensitive_cols ` (optional, default=False): Whether your source table has case sensitive column names. If true, keeps the case of the column names from the source.
 
 
 ### Usage:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ model.
 * `source_name` (required): The source you wish to generate base model SQL for.
 * `table_name` (required): The source table you wish to generate base model SQL for.
 * `leading_commas` (optional, default=False): Whether you want your commas to be leading (vs trailing).
+* `case_sensitive_cols ` (optional, default=False): Whether your source table has case sensitive column names.
 
 
 ### Usage:

--- a/integration_tests/macros/operations/create_source_table.sql
+++ b/integration_tests/macros/operations/create_source_table.sql
@@ -25,4 +25,21 @@ create table {{ target_schema }}.codegen_integration_tests__data_source_table as
 
 {{ run_query(create_table_sql) }}
 
+{% set drop_table_sql_case_sensitive %}
+drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive
+{% endset %}
+
+{{ run_query(drop_table_sql_case_sensitive) }}
+
+
+{% set create_table_sql_case_sensitive %}
+create table {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive as (
+    select
+        1 as "My_Integer_Col",
+        true as "My_Bool_Col"
+)
+{% endset %}
+
+{{ run_query(create_table_sql_case_sensitive) }}
+
 {% endmacro %}

--- a/integration_tests/macros/operations/create_source_table.sql
+++ b/integration_tests/macros/operations/create_source_table.sql
@@ -1,5 +1,12 @@
 {% macro create_source_table() %}
 
+{% if target.type == "redshift" %} 
+{% set disable_case_sensitive %}
+reset enable_case_sensitive_identifier;
+{% endset %}
+{{ run_query(disable_case_sensitive) }}
+{% endif %}
+
 {% set target_schema=api.Relation.create(
     database=target.database,
     schema="codegen_integration_tests__data_source_schema"
@@ -31,6 +38,12 @@ drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_
 
 {{ run_query(drop_table_sql_case_sensitive) }}
 
+{% if target.type == "redshift" %} 
+{% set enable_case_sensitive %}
+set enable_case_sensitive_identifier to true;
+{% endset %}
+{{ run_query(enable_case_sensitive) }}
+{% endif %}
 
 {% set create_table_sql_case_sensitive %}
 create table {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive as (

--- a/integration_tests/macros/operations/create_source_table.sql
+++ b/integration_tests/macros/operations/create_source_table.sql
@@ -48,8 +48,8 @@ set enable_case_sensitive_identifier to true;
 {% set create_table_sql_case_sensitive %}
 create table {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive as (
     select
-        1 as "My_Integer_Col",
-        true as "My_Bool_Col"
+        1 as {% if target.type == "bigquery" %}My_Integer_Col{% else %}"My_Integer_Col"{% endif %},
+        true as {% if target.type == "bigquery" %}My_Bool_Col{% else %}"My_Bool_Col"{% endif %}
 )
 {% endset %}
 

--- a/integration_tests/models/source.yml
+++ b/integration_tests/models/source.yml
@@ -4,3 +4,4 @@ sources:
   - name: codegen_integration_tests__data_source_schema
     tables:
       - name: codegen_integration_tests__data_source_table
+      - name: codegen_integration_tests__data_source_table_case_sensitive

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -1,0 +1,30 @@
+
+{% set actual_base_model = codegen.generate_base_model(
+    source_name='codegen_integration_tests__data_source_schema',
+    table_name='codegen_integration_tests__data_source_table_case_sensitive',
+    leading_commas=True,
+    case_sensitive_cols=True
+  )
+%}
+
+{% set expected_base_model %}
+with source as (
+
+    select * from {%raw%}{{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table_case_sensitive') }}{%endraw%}
+
+),
+
+renamed as (
+
+    select
+        "My_Integer_Col"
+        , "My_Bool_Col"
+
+    from source
+
+)
+
+select * from renamed
+{% endset %}
+
+{{ assert_equal (actual_base_model | trim, expected_base_model | trim) }}

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -17,8 +17,8 @@ with source as (
 renamed as (
 
     select
-        "My_Integer_Col"
-        , "My_Bool_Col"
+        {% if target.type == "bigquery" %}My_Integer_Col{% else %}"My_Integer_Col"{% endif %}
+        , {% if target.type == "bigquery" %}My_Bool_Col{% else %}"My_Bool_Col"{% endif %}
 
     from source
 

--- a/integration_tests/tests/test_generate_base_models_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_base_models_case_sensitive.sql
@@ -15,8 +15,8 @@ with source as (
 renamed as (
 
     select
-        "My_Integer_Col",
-        "My_Bool_Col"
+        {% if target.type == "bigquery" %}My_Integer_Col{% else %}"My_Integer_Col"{% endif %},
+        {% if target.type == "bigquery" %}My_Bool_Col{% else %}"My_Bool_Col"{% endif %}
 
     from source
 

--- a/integration_tests/tests/test_generate_base_models_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_base_models_case_sensitive.sql
@@ -1,0 +1,28 @@
+{% set actual_base_model = codegen.generate_base_model(
+    source_name='codegen_integration_tests__data_source_schema',
+    table_name='codegen_integration_tests__data_source_table_case_sensitive',
+    case_sensitive_cols=True
+  )
+%}
+
+{% set expected_base_model %}
+with source as (
+
+    select * from {%raw%}{{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table_case_sensitive') }}{%endraw%}
+
+),
+
+renamed as (
+
+    select
+        "My_Integer_Col",
+        "My_Bool_Col"
+
+    from source
+
+)
+
+select * from renamed
+{% endset %}
+
+{{ assert_equal (actual_base_model | trim, expected_base_model | trim) }}

--- a/integration_tests/tests/test_generate_base_models_leading.sql
+++ b/integration_tests/tests/test_generate_base_models_leading.sql
@@ -2,7 +2,7 @@
 {% set actual_base_model = codegen.generate_base_model(
     source_name='codegen_integration_tests__data_source_schema',
     table_name='codegen_integration_tests__data_source_table',
-    leading_commas=True,
+    leading_commas=True
   )
 %}
 

--- a/integration_tests/tests/test_generate_source.sql
+++ b/integration_tests/tests/test_generate_source.sql
@@ -8,7 +8,7 @@
 version: 2
 
 sources:
-  - name: {{ raw_schema | trim }}
+  - name: {{ raw_schema | trim | lower }}
     tables:
       - name: data__a_relation
       - name: data__b_relation

--- a/integration_tests/tests/test_generate_source_all_args.sql
+++ b/integration_tests/tests/test_generate_source_all_args.sql
@@ -16,7 +16,7 @@
 version: 2
 
 sources:
-  - name: {{ raw_schema | trim }}
+  - name: {{ raw_schema | trim | lower }}
     tables:
       - name: data__a_relation
         columns:

--- a/integration_tests/tests/test_generate_source_exclude.sql
+++ b/integration_tests/tests/test_generate_source_exclude.sql
@@ -8,7 +8,7 @@
 version: 2
 
 sources:
-  - name: {{ raw_schema | trim }}
+  - name: {{ raw_schema | trim | lower}}
     tables:
       - name: data__b_relation
 {% endset %}

--- a/integration_tests/tests/test_generate_source_table_pattern.sql
+++ b/integration_tests/tests/test_generate_source_table_pattern.sql
@@ -8,7 +8,7 @@
 version: 2
 
 sources:
-  - name: {{ raw_schema | trim }}
+  - name: {{ raw_schema | trim | lower }}
     tables:
       - name: data__b_relation
 {% endset %}

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -16,11 +16,11 @@ renamed as (
     select
         {%- if leading_commas -%}
         {%- for column in column_names %}
-        {{", " if not loop.first}}{{ column | lower if not case_sensitive_cols else "\"" ~ column ~ "\"" }}
+        {{", " if not loop.first}}{% if not case_sensitive_cols %}{{ column | lower }}{% elif target.type == "bigquery" %}{{ column }}{% else %}{{ "\"" ~ column ~ "\"" }}{% endif %}
         {%- endfor %}
         {%- else -%}
         {%- for column in column_names %}
-        {{ column | lower if not case_sensitive_cols else "\"" ~ column ~ "\"" }}{{"," if not loop.last}}
+        {% if not case_sensitive_cols %}{{ column | lower }}{% elif target.type == "bigquery" %}{{ column }}{% else %}{{ "\"" ~ column ~ "\"" }}{% endif %}{{"," if not loop.last}}
         {%- endfor -%}
         {%- endif %}
 

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -1,4 +1,4 @@
-{% macro generate_base_model(source_name, table_name, leading_commas=False) %}
+{% macro generate_base_model(source_name, table_name, leading_commas=False, case_sensitive_cols=False) %}
 
 {%- set source_relation = source(source_name, table_name) -%}
 
@@ -16,11 +16,11 @@ renamed as (
     select
         {%- if leading_commas -%}
         {%- for column in column_names %}
-        {{", " if not loop.first}}{{ column | lower }}
+        {{", " if not loop.first}}{{ column | lower if not case_sensitive_cols else "\"" ~ column ~ "\"" }}
         {%- endfor %}
         {%- else -%}
         {%- for column in column_names %}
-        {{ column | lower }}{{"," if not loop.last}}
+        {{ column | lower if not case_sensitive_cols else "\"" ~ column ~ "\"" }}{{"," if not loop.last}}
         {%- endfor -%}
         {%- endif %}
 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
I added an argument `case_sensitive_cols` to `generate_base_model` macro to allow this macro to still work for source tables with case sensitive column names. 

## Checklist
- [x] I have verified that these changes work locally (Snowflake)
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
