### PR TITLE
Feature/generate_source_descs_iss64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 ## New features
 - Add support for importing descriptions from columns with the same names in upstream models. It is available by setting the parameter `upstream_descriptions` to `True` in `generate_model_yaml` ([#61](https://github.com/dbt-labs/dbt-codegen/pull/61))
+- Add support for including description placeholders for the source and table, which changes the behavior of `generate_source` when `include_descriptions` is set to `True`. Previous logic only created description placeholders for the columns. 
+- Add optional `name` arg to `generate_source`
 
 # dbt-codegen v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ which you can then paste into a schema file.
 
 ### Arguments
 * `schema_name` (required): The schema name that contains your source data
+* `name` (optional, default = schema_name): The name of your source
 * `database_name` (optional, default=target.database): The database that your
 source data is in.
 * `generate_columns` (optional, default=False): Whether you want to add the

--- a/integration_tests/tests/test_generate_source_all_args.sql
+++ b/integration_tests/tests/test_generate_source_all_args.sql
@@ -3,6 +3,7 @@
 -- test all args
 {% set actual_source_yaml = codegen.generate_source(
     schema_name=raw_schema,
+    name = schema_name,
     table_pattern='%',
     exclude='',
     database_name=target.database,
@@ -17,8 +18,10 @@ version: 2
 
 sources:
   - name: {{ raw_schema | trim }}
+    description: ""
     tables:
       - name: data__a_relation
+        description: ""
         columns:
           - name: col_a
             description: ""
@@ -26,6 +29,7 @@ sources:
             description: ""
 
       - name: data__b_relation
+        description: ""
         columns:
           - name: col_a
             description: ""

--- a/integration_tests/tests/test_generate_source_all_args.sql
+++ b/integration_tests/tests/test_generate_source_all_args.sql
@@ -3,7 +3,7 @@
 -- test all args
 {% set actual_source_yaml = codegen.generate_source(
     schema_name=raw_schema,
-    name = schema_name,
+    name = raw_schema,
     table_pattern='%',
     exclude='',
     database_name=target.database,

--- a/integration_tests/tests/test_generate_source_table_descriptions.sql
+++ b/integration_tests/tests/test_generate_source_table_descriptions.sql
@@ -1,0 +1,21 @@
+
+{% set raw_schema = generate_schema_name('raw_data') %}
+
+-- test default args
+{% set actual_source_yaml = codegen.generate_source(raw_schema, include_descriptions=True) %}
+
+{% set expected_source_yaml %}
+version: 2
+
+sources:
+  - name: {{ raw_schema | trim }}
+    description: ""
+    tables:
+      - name: data__a_relation
+        description: ""
+      - name: data__b_relation
+        description: ""
+{% endset %}
+
+
+{{ assert_equal (actual_source_yaml | trim, expected_source_yaml | trim) }}

--- a/integration_tests/tests/test_generate_source_table_name.sql
+++ b/integration_tests/tests/test_generate_source_table_name.sql
@@ -1,0 +1,20 @@
+
+{% set raw_schema = generate_schema_name('raw_data') %}
+
+-- test default args
+{% set actual_source_yaml = codegen.generate_source(raw_schema, name='raw') %}
+
+{% set expected_source_yaml %}
+version: 2
+
+sources:
+  - name: 'raw'
+    schema: {{ raw_schema | trim }}
+    tables:
+      - name: data__a_relation
+      - name: data__b_relation
+
+{% endset %}
+
+
+{{ assert_equal (actual_source_yaml | trim, expected_source_yaml | trim) }}

--- a/integration_tests/tests/test_generate_source_table_name.sql
+++ b/integration_tests/tests/test_generate_source_table_name.sql
@@ -8,7 +8,7 @@
 version: 2
 
 sources:
-  - name: 'raw'
+  - name: raw
     schema: {{ raw_schema | trim }}
     tables:
       - name: data__a_relation

--- a/macros/generate_source.sql
+++ b/macros/generate_source.sql
@@ -15,17 +15,24 @@
 
 
 ---
-{% macro generate_source(schema_name, database_name=target.database, generate_columns=False, include_descriptions=False, table_pattern='%', exclude='') %}
+{% macro generate_source(schema_name, name = schema_name, database_name=target.database, generate_columns=False, include_descriptions=False, table_pattern='%', exclude='') %}
 
 {% set sources_yaml=[] %}
-
 {% do sources_yaml.append('version: 2') %}
 {% do sources_yaml.append('') %}
 {% do sources_yaml.append('sources:') %}
-{% do sources_yaml.append('  - name: ' ~ schema_name | lower) %}
+{% do sources_yaml.append('  - name: ' ~ name | lower) %}
+
+{% if include_descriptions %}
+    {% do sources_yaml.append('    description: ""' ) %}
+{% endif %}
 
 {% if database_name != target.database %}
 {% do sources_yaml.append('    database: ' ~ database_name | lower) %}
+{% endif %}
+
+{% if schema_name != name %}
+{% do sources_yaml.append('    schema: ' ~ schema_name | lower) %}
 {% endif %}
 
 {% do sources_yaml.append('    tables:') %}
@@ -34,7 +41,9 @@
 
 {% for table in tables %}
     {% do sources_yaml.append('      - name: ' ~ table | lower ) %}
-
+    {% if include_descriptions %}
+        {% do sources_yaml.append('        description: ""' ) %}
+    {% endif %}
     {% if generate_columns %}
     {% do sources_yaml.append('        columns:') %}
 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [X] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Currently, generate_source has an option to set include_descriptions = True, but this parameters only includes descriptions at the column level. Ideally, description placeholders would also be generated for the source and tables as well. Additionally, the required parameter for generate_source macro is the schema name, but there is no option to input a name value. It is possible that a user would like to name their source a different name from the schema name. See [issue](https://github.com/dbt-labs/dbt-codegen/issues/64) -->

## Checklist
- [X] I have verified that these changes work locally
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [X ] I have added an entry to CHANGELOG.md
