### PR TITLE
update utils range to match audit helper

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.9.0", "<2.0.0"]
+    version: [">=0.8.0", "<2.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.9.0"]
+    version: [">=0.9.0", "<2.0.0"]


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
This PR updates the pinned version requirements for dbt_utils to require utils version `0.9.0` or above. Currently other pacakges, like audit_helper [already require this](https://github.com/dbt-labs/dbt-audit-helper/blob/3f25a06ebf2d9ded02276c97fbf14e2f77b7073b/packages.yml#L3), and trying to install the latest version of these packages together causes dependency mismatch issues. 

Local integration tests pass on postgres with this change!
<img width="777" alt="image" src="https://user-images.githubusercontent.com/73915542/189391611-a3113104-ed49-4858-9700-9b39470160cd.png">



## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
