### PR TITLE
Suggestion to materialize base models as view or table

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ model.
 * `table_name` (required): The source table you wish to generate base model SQL for.
 * `leading_commas` (optional, default=False): Whether you want your commas to be leading (vs trailing).
 * `case_sensitive_cols ` (optional, default=False): Whether your source table has case sensitive column names. If true, keeps the case of the column names from the source.
-* `materialization` (optional, default='table'): Set materialization to table or view.
+* `materialized` (optional, default=None): Set materialization style (e.g. table, view, incremental) inside of the model's `config` block. If not set, materialization style will be controlled by `dbt_project.yml`
 
 
 ### Usage:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ model.
 * `table_name` (required): The source table you wish to generate base model SQL for.
 * `leading_commas` (optional, default=False): Whether you want your commas to be leading (vs trailing).
 * `case_sensitive_cols ` (optional, default=False): Whether your source table has case sensitive column names. If true, keeps the case of the column names from the source.
+* `materialize_as_view` (optional, default=False): Whether you want the base model to be a view.
 
 
 ### Usage:
@@ -88,7 +89,8 @@ model.
 ```
 {{ codegen.generate_base_model(
     source_name='raw_jaffle_shop',
-    table_name='customers'
+    table_name='customers',
+    materialize_as_view=True
 ) }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ model.
 {{ codegen.generate_base_model(
     source_name='raw_jaffle_shop',
     table_name='customers',
-    materialization='table'
+    materialized='table'
 ) }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ model.
 * `table_name` (required): The source table you wish to generate base model SQL for.
 * `leading_commas` (optional, default=False): Whether you want your commas to be leading (vs trailing).
 * `case_sensitive_cols ` (optional, default=False): Whether your source table has case sensitive column names. If true, keeps the case of the column names from the source.
-* `materialize_as_view` (optional, default=False): Whether you want the base model to be a view.
+* `materialization` (optional, default='table'): Set materialization to table or view.
 
 
 ### Usage:
@@ -90,7 +90,7 @@ model.
 {{ codegen.generate_base_model(
     source_name='raw_jaffle_shop',
     table_name='customers',
-    materialize_as_view=True
+    materialization='table'
 ) }}
 ```
 

--- a/integration_tests/tests/test_generate_base_models.sql
+++ b/integration_tests/tests/test_generate_base_models.sql
@@ -6,7 +6,6 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models.sql
+++ b/integration_tests/tests/test_generate_base_models.sql
@@ -6,7 +6,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table') }}" }}
+{{ "{{ config(materialized=None) }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models.sql
+++ b/integration_tests/tests/test_generate_base_models.sql
@@ -6,7 +6,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table' }}" }}
+{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models.sql
+++ b/integration_tests/tests/test_generate_base_models.sql
@@ -6,7 +6,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized=None) }}" }}
+{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models.sql
+++ b/integration_tests/tests/test_generate_base_models.sql
@@ -6,6 +6,8 @@
 %}
 
 {% set expected_base_model %}
+{{ "{{ config(materialized='table' }}" }}
+
 with source as (
 
     select * from {%raw%}{{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table') }}{%endraw%}

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -9,7 +9,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table' }}" }}
+{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -9,7 +9,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='"+materialization+"' }}" }}
+{{ "{{ config(materialized='view' }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -4,12 +4,12 @@
     table_name='codegen_integration_tests__data_source_table_case_sensitive',
     leading_commas=True,
     case_sensitive_cols=True,
-    materialization='view'
+    materialization='table'
   )
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='view' }}" }}
+{{ "{{ config(materialized='table' }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -3,11 +3,14 @@
     source_name='codegen_integration_tests__data_source_schema',
     table_name='codegen_integration_tests__data_source_table_case_sensitive',
     leading_commas=True,
-    case_sensitive_cols=True
+    case_sensitive_cols=True,
+    materialization='view'
   )
 %}
 
 {% set expected_base_model %}
+{{ "{{ config(materialized='"+materialization+"' }}" }}
+
 with source as (
 
     select * from {%raw%}{{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table_case_sensitive') }}{%endraw%}

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -4,12 +4,12 @@
     table_name='codegen_integration_tests__data_source_table_case_sensitive',
     leading_commas=True,
     case_sensitive_cols=True,
-    materialization='table'
+    materialized=None
   )
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table') }}" }}
+{{ "{{ config(materialized=None) }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -4,7 +4,7 @@
     table_name='codegen_integration_tests__data_source_table_case_sensitive',
     leading_commas=True,
     case_sensitive_cols=True,
-    materialized=None
+    materialized='table'
   )
 %}
 

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -9,7 +9,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized=None) }}" }}
+{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_base_models_case_sensitive.sql
@@ -6,7 +6,6 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_base_models_case_sensitive.sql
@@ -6,7 +6,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table') }}" }}
+{{ "{{ config(materialized=None) }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_base_models_case_sensitive.sql
@@ -6,7 +6,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table' }}" }}
+{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_base_models_case_sensitive.sql
@@ -6,7 +6,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized=None) }}" }}
+{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_base_models_case_sensitive.sql
@@ -6,6 +6,8 @@
 %}
 
 {% set expected_base_model %}
+{{ "{{ config(materialized='table' }}" }}
+
 with source as (
 
     select * from {%raw%}{{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table_case_sensitive') }}{%endraw%}

--- a/integration_tests/tests/test_generate_base_models_leading.sql
+++ b/integration_tests/tests/test_generate_base_models_leading.sql
@@ -7,7 +7,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table') }}" }}
+{{ "{{ config(materialized=None) }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_leading.sql
+++ b/integration_tests/tests/test_generate_base_models_leading.sql
@@ -7,7 +7,6 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_leading.sql
+++ b/integration_tests/tests/test_generate_base_models_leading.sql
@@ -7,7 +7,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized='table' }}" }}
+{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/integration_tests/tests/test_generate_base_models_leading.sql
+++ b/integration_tests/tests/test_generate_base_models_leading.sql
@@ -7,6 +7,8 @@
 %}
 
 {% set expected_base_model %}
+{{ "{{ config(materialized='table' }}" }}
+
 with source as (
 
     select * from {%raw%}{{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table') }}{%endraw%}

--- a/integration_tests/tests/test_generate_base_models_leading.sql
+++ b/integration_tests/tests/test_generate_base_models_leading.sql
@@ -7,7 +7,7 @@
 %}
 
 {% set expected_base_model %}
-{{ "{{ config(materialized=None) }}" }}
+{{ "{{ config(materialized='table') }}" }}
 
 with source as (
 

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -1,13 +1,13 @@
-{% macro generate_base_model(source_name, table_name, leading_commas=False, case_sensitive_cols=False, materialize_as_view=False) %}
+{% macro generate_base_model(source_name, table_name, leading_commas=False, case_sensitive_cols=False, materialization='table') %}
 
 {%- set source_relation = source(source_name, table_name) -%}
 
 {%- set columns = adapter.get_columns_in_relation(source_relation) -%}
 {% set column_names=columns | map(attribute='name') %}
 {% set base_model_sql %}
-{%- if materialize_as_view -%}
-{{ "{{ config(materialized='view') }}" }}
-{%- endif %}
+
+{{ "{{ config(materialized='"+materialization+"' }}" }}
+
 with source as (
 
     select * from {% raw %}{{ source({% endraw %}'{{ source_name }}', '{{ table_name }}'{% raw %}) }}{% endraw %}

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -10,7 +10,7 @@
     {{ "{{ config(materialized='" ~ materialized ~ "') }}" }}
 {%- else -%}
     {{ "{{ config(materialized='table') }}" }}
-{%- endif -%}
+{% endif %}
 
 with source as (
 

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -8,8 +8,6 @@
 
 {%- if materialized is not none -%}
     {{ "{{ config(materialized='" ~ materialized ~ "') }}" }}
-{%- else -%}
-    {{ "{{ config(materialized='table') }}" }}
 {%- endif %}
 
 with source as (

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -10,7 +10,7 @@
     {{ "{{ config(materialized='" ~ materialized ~ "') }}" }}
 {%- else -%}
     {{ "{{ config(materialized='table') }}" }}
-{% endif %}
+{%- endif %}
 
 with source as (
 

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -1,10 +1,13 @@
-{% macro generate_base_model(source_name, table_name, leading_commas=False, case_sensitive_cols=False) %}
+{% macro generate_base_model(source_name, table_name, leading_commas=False, case_sensitive_cols=False, materialize_as_view=False) %}
 
 {%- set source_relation = source(source_name, table_name) -%}
 
 {%- set columns = adapter.get_columns_in_relation(source_relation) -%}
 {% set column_names=columns | map(attribute='name') %}
 {% set base_model_sql %}
+{%- if materialize_as_view -%}
+{{ "{{ config(materialized='view') }}" }}
+{%- endif %}
 with source as (
 
     select * from {% raw %}{{ source({% endraw %}'{{ source_name }}', '{{ table_name }}'{% raw %}) }}{% endraw %}

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -6,7 +6,7 @@
 {% set column_names=columns | map(attribute='name') %}
 {% set base_model_sql %}
 
-{%- if materialized is not None -%}
+{%- if materialized is not none -%}
     {{ "{{ config(materialized='" ~ materialized ~ "') }}" }}
 {%- else -%}
     {{ "{{ config(materialized='table') }}" }}

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -6,7 +6,7 @@
 {% set column_names=columns | map(attribute='name') %}
 {% set base_model_sql %}
 
-{{ "{{ config(materialized='"+materialization+"' }}" }}
+{{ "{{ config(materialized='"+materialization+"') }}" }}
 
 with source as (
 

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -1,4 +1,4 @@
-{% macro generate_base_model(source_name, table_name, leading_commas=False, case_sensitive_cols=False, materialization='table') %}
+{% macro generate_base_model(source_name, table_name, leading_commas=False, case_sensitive_cols=False, materialized=None) %}
 
 {%- set source_relation = source(source_name, table_name) -%}
 
@@ -6,7 +6,11 @@
 {% set column_names=columns | map(attribute='name') %}
 {% set base_model_sql %}
 
-{{ "{{ config(materialized='"+materialization+"') }}" }}
+{%- if materialized is not None -%}
+    {{ "{{ config(materialized='" ~ materialized ~ "') }}" }}
+{%- else -%}
+    {{ "{{ config(materialized='table') }}" }}
+{%- endif -%}
 
 with source as (
 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [X] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
Add `materialization` parameter to `generate_base_model` to allow users to choose whether to materialize the model as a table or a view.

Since base models ought not to do much transformation and provide a lightweight layer atop source tables, it is not uncommon to materialize them as views while having the default materialization for a project be tables, since heavier transformation models ought not be computed on the fly as they would be on a view.

This change would also make it possible to generate base models materialized as views in bulk using the [dbt-generator](https://github.com/tuanchris/dbt-generator) package.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
