### PR TITLE
Feature/generate multiple models yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ select * from renamed
 4. Paste the output in to a model, and refactor as required.
 
 ## generate_model_yaml ([source](macros/generate_model_yaml.sql))
-This macro generates the YAML for a model, which you can then paste into a
+This macro generates the YAML for a model or list of models, which you can then paste into a
 schema.yml file.
 
 ### Arguments:
-* `model_name` (required): The model you wish to generate YAML for.
+* `model_name` (required): The model or list of models you wish to generate YAML for.
 * `upstream_descriptions` (optional, default=False): Whether you want to include descriptions for identical column names from upstream models.
 
 ### Usage:
@@ -146,7 +146,7 @@ schema.yml file.
 Alternatively, call the macro as an [operation](https://docs.getdbt.com/docs/using-operations):
 
 ```
-$ dbt run-operation generate_model_yaml --args '{"model_name": "customers"}'
+$ dbt run-operation generate_model_yaml --args '{"model_name": ["customers", "orders"]}'
 ```
 
 3. The YAML for a base model will be logged to the command line

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ select * from renamed
 4. Paste the output in to a model, and refactor as required.
 
 ## generate_model_yaml ([source](macros/generate_model_yaml.sql))
-This macro generates the YAML for a model or list of models, which you can then paste into a
+This macro generates the YAML for a list of model(s), which you can then paste into a
 schema.yml file.
 
 ### Arguments:
-* `model_name` (required): The model or list of models you wish to generate YAML for.
+* `model_names` (required): The model(s) you wish to generate YAML for.
 * `upstream_descriptions` (optional, default=False): Whether you want to include descriptions for identical column names from upstream models.
 
 ### Usage:
@@ -139,23 +139,23 @@ schema.yml file.
 
 ```
 {{ codegen.generate_model_yaml(
-    model_name='customers'
+    model_names=['customers']
 ) }}
 ```
 
 Alternatively, call the macro as an [operation](https://docs.getdbt.com/docs/using-operations):
 
 ```
-$ dbt run-operation generate_model_yaml --args '{"model_name": "customers"}'
+$ dbt run-operation generate_model_yaml --args '{"model_names": ["customers"]}'
 ```
 
 or
 
 ```
-$ dbt run-operation generate_model_yaml --args '{"model_name": ["customers", "orders"]}'
+$ dbt run-operation generate_model_yaml --args '{"model_names": ["customers", "orders"]}'
 ```
 
-3. The YAML for the model(s) will be logged to the command line
+3. The YAML for a base model(s) will be logged to the command line
 
 ```
 version: 2

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ schema.yml file.
 Alternatively, call the macro as an [operation](https://docs.getdbt.com/docs/using-operations):
 
 ```
+$ dbt run-operation generate_model_yaml --args '{"model_name": "customers"}'
+```
+
+or
+
+```
 $ dbt run-operation generate_model_yaml --args '{"model_name": ["customers", "orders"]}'
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ or
 $ dbt run-operation generate_model_yaml --args '{"model_name": ["customers", "orders"]}'
 ```
 
-3. The YAML for a base model will be logged to the command line
+3. The YAML for the model(s) will be logged to the command line
 
 ```
 version: 2

--- a/README.md
+++ b/README.md
@@ -149,12 +149,6 @@ Alternatively, call the macro as an [operation](https://docs.getdbt.com/docs/usi
 $ dbt run-operation generate_model_yaml --args '{"model_names": ["customers"]}'
 ```
 
-or
-
-```
-$ dbt run-operation generate_model_yaml --args '{"model_names": ["customers", "orders"]}'
-```
-
 3. The YAML for a base model(s) will be logged to the command line
 
 ```

--- a/integration_tests/tests/test_generate_model_struct_yaml.sql
+++ b/integration_tests/tests/test_generate_model_struct_yaml.sql
@@ -10,7 +10,7 @@
 ) %}
 
 {% set actual_source_yaml = codegen.generate_model_yaml(
-    model_name='model_struct'
+    model_names=['model_struct']
   )
 %}
 

--- a/integration_tests/tests/test_generate_model_yaml.sql
+++ b/integration_tests/tests/test_generate_model_yaml.sql
@@ -1,5 +1,5 @@
 {% set actual_model_yaml = codegen.generate_model_yaml(
-    model_name='data__a_relation'
+    model_names=['data__a_relation']
   )
 %}
 

--- a/integration_tests/tests/test_generate_model_yaml_multiple_models.sql
+++ b/integration_tests/tests/test_generate_model_yaml_multiple_models.sql
@@ -1,5 +1,5 @@
 {% set actual_model_yaml = codegen.generate_model_yaml(
-    model_name=['data__a_relation','data__b_relation']
+    model_names=['data__a_relation','data__b_relation']
   )
 %}
 

--- a/integration_tests/tests/test_generate_model_yaml_multiple_models.sql
+++ b/integration_tests/tests/test_generate_model_yaml_multiple_models.sql
@@ -1,0 +1,30 @@
+{% set actual_model_yaml = codegen.generate_model_yaml(
+    model_name=['data__a_relation','data__b_relation']
+  )
+%}
+
+{% set expected_model_yaml %}
+version: 2
+
+models:
+  - name: data__a_relation
+    description: ""
+    columns:
+      - name: col_a
+        description: ""
+
+      - name: col_b
+        description: ""
+
+  - name: data__b_relation
+    description: ""
+    columns:
+      - name: col_a
+        description: ""
+
+      - name: col_b
+        description: ""
+
+{% endset %}
+
+{{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}

--- a/integration_tests/tests/test_generate_model_yaml_upstream_descriptions.sql
+++ b/integration_tests/tests/test_generate_model_yaml_upstream_descriptions.sql
@@ -1,5 +1,5 @@
 {% set actual_model_yaml = codegen.generate_model_yaml(
-    model_name='child_model',
+    model_names=['child_model'],
     upstream_descriptions=True
   )
 %}

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -29,13 +29,13 @@
         {{ exceptions.raise_compiler_error("The name argument to ref() must be a list, got <class 'string'>: " ~ number) }}
     {% else %}
         {% for model in model_names %}
-            {% set column_desc_dict =  codegen.build_dict_column_descriptions(model) if upstream_descriptions else {} %}
             {% do model_yaml.append('  - name: ' ~ model | lower) %}
             {% do model_yaml.append('    description: ""') %}
             {% do model_yaml.append('    columns:') %}
 
             {% set relation=ref(model) %}
             {%- set columns = adapter.get_columns_in_relation(relation) -%}
+            {% set column_desc_dict =  codegen.build_dict_column_descriptions(model) if upstream_descriptions else {} %}
 
             {% for column in columns %}
                 {% set model_yaml = codegen.generate_column_yaml(column, model_yaml, column_desc_dict) %}

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -26,7 +26,7 @@
     {% do model_yaml.append('models:') %}
 
     {% if model_names is string %}
-        {{ exceptions.raise_compiler_error(("The `model_names` argument must always be a list, even if there is only one model.") }}
+        {{ exceptions.raise_compiler_error("The `model_names` argument must always be a list, even if there is only one model.") }}
     {% else %}
         {% for model in model_names %}
             {% do model_yaml.append('  - name: ' ~ model | lower) %}

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -26,7 +26,7 @@
     {% do model_yaml.append('models:') %}
 
     {% if model_names is string %}
-        {{ exceptions.raise_compiler_error("The name argument to ref() must be a list, got <class 'string'>: " ~ number) }}
+        {{ exceptions.raise_compiler_error(("The `model_names` argument must always be a list, even if there is only one model.") }}
     {% else %}
         {% for model in model_names %}
             {% do model_yaml.append('  - name: ' ~ model | lower) %}

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -17,24 +17,34 @@
     {% do return(model_yaml) %}
 {% endmacro %}
 
-{% macro generate_model_yaml(model_name, upstream_descriptions=False) %}
+{% macro generate_model_yaml(model_name=[], upstream_descriptions=False) %}
 
-{% set model_yaml=[] %}
-{% set column_desc_dict =  codegen.build_dict_column_descriptions(model_name) if upstream_descriptions else {} %}
+    {% set model_yaml=[] %}
+    {% set column_desc_dict =  codegen.build_dict_column_descriptions(model_name) if upstream_descriptions else {} %}
 
-{% do model_yaml.append('version: 2') %}
-{% do model_yaml.append('') %}
-{% do model_yaml.append('models:') %}
-{% do model_yaml.append('  - name: ' ~ model_name | lower) %}
-{% do model_yaml.append('    description: ""') %}
-{% do model_yaml.append('    columns:') %}
+    {% do model_yaml.append('version: 2') %}
+    {% do model_yaml.append('') %}
+    {% do model_yaml.append('models:') %}
 
-{% set relation=ref(model_name) %}
-{%- set columns = adapter.get_columns_in_relation(relation) -%}
+    {% if model_name is string %}
+        {% set model_name_list=[] %}
+        {% do model_name_list.append(model_name) %}
+    {% else %}
+        {% set model_name_list=model_name %}
+    {% endif %}
 
-{% for column in columns %}
-    {% set model_yaml = codegen.generate_column_yaml(column, model_yaml, column_desc_dict) %}
-{% endfor %}
+    {% for model in model_name_list %}
+        {% do model_yaml.append('  - name: ' ~ model | lower) %}
+        {% do model_yaml.append('    description: ""') %}
+        {% do model_yaml.append('    columns:') %}
+
+        {% set relation=ref(model) %}
+        {%- set columns = adapter.get_columns_in_relation(relation) -%}
+
+        {% for column in columns %}
+            {% set model_yaml = codegen.generate_column_yaml(column, model_yaml, column_desc_dict) %}
+        {% endfor %}
+    {% endfor %}
 
 {% if execute %}
 

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -20,7 +20,6 @@
 {% macro generate_model_yaml(model_names=[], upstream_descriptions=False) %}
 
     {% set model_yaml=[] %}
-    {% set column_desc_dict =  codegen.build_dict_column_descriptions(model_name) if upstream_descriptions else {} %}
 
     {% do model_yaml.append('version: 2') %}
     {% do model_yaml.append('') %}
@@ -30,6 +29,7 @@
         {{ exceptions.raise_compiler_error("The name argument to ref() must be a list, got <class 'string'>: " ~ number) }}
     {% else %}
         {% for model in model_names %}
+            {% set column_desc_dict =  codegen.build_dict_column_descriptions(model) if upstream_descriptions else {} %}
             {% do model_yaml.append('  - name: ' ~ model | lower) %}
             {% do model_yaml.append('    description: ""') %}
             {% do model_yaml.append('    columns:') %}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
closes #68 
Added code that allows for generate_model_yaml to accept multiple model arguments as a list, or one model as a string. 
Updated README to reflect this feature.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

## Other comments

- Should I add an entry to the CHANELOG.md for this?
- Also, I am creating a pull request to merge into dev/ — should this be merged into main/ instead?