### PR TITLE
Use print for outputting codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
 - [@handle](https://github.com/handle) (#XXX)
 --->
 
+# Unreleased
+## Breaking changes
+## New features
+## Quality of life
+- Now uses `print` instead of `log` to output the generated text into the console. This enables you to invoke dbt with the `--quiet` flag and directly pipe the codegen output into a new file, ending up with valid yaml
+
+## Under the hood
+## Contributors:
+- [@JorgenG](https://github.com/JorgenG) (#86)
+
 # dbt-codegen v0.7.0
 
 ## 🚨 Breaking change

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ want to subselect from all available tables within a given schema.
 * `exclude` (optional, default=''): A string you want to exclude from the selection criteria
 * `name` (optional, default=schema_name): The name of your source
 
+### Outputting to a file
+If you use the `dbt run-operation` approach it is possible to output directly to a file by piping the output to a new file and using the `--quiet` CLI flag:
+
+```
+dbt --quiet run-operation generate_model_yaml --args '{"model_name": "stg_jaffle_shop__orders"}' > models/staging/jaffle_shop/stg_jaffle_shop__orders.yml
+```
+
 ### Usage:
 1. Copy the macro into a statement tab in the dbt Cloud IDE, or into an analysis file, and compile your code
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'codegen'
 version: '0.5.0'
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.1.0", "<2.0.0"]
 config-version: 2
 
 target-path: "target"

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -33,7 +33,7 @@ select * from renamed
 
 {% if execute %}
 
-{{ log(base_model_sql, info=True) }}
+{{ print(base_model_sql) }}
 {% do return(base_model_sql) %}
 
 {% endif %}

--- a/macros/generate_model_import_ctes.sql
+++ b/macros/generate_model_import_ctes.sql
@@ -167,7 +167,7 @@
 
 {%- if execute -%}
 
-{{ log(model_import_ctes, info=True) }}
+{{ print(model_import_ctes) }}
 {% do return(model_import_ctes) %}
 
 {% endif %}

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -39,7 +39,7 @@
 {% if execute %}
 
     {% set joined = model_yaml | join ('\n') %}
-    {{ log(joined, info=True) }}
+    {{ print(joined) }}
     {% do return(joined) %}
 
 {% endif %}

--- a/macros/generate_source.sql
+++ b/macros/generate_source.sql
@@ -74,7 +74,7 @@
 {% if execute %}
 
     {% set joined = sources_yaml | join ('\n') %}
-    {{ log(joined, info=True) }}
+    {{ print(joined) }}
     {% do return(joined) %}
 
 {% endif %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
This PR switches from using the `log` function to using the `print` function. The main motivation for doing this is to enable piping the output from a codegen run operation command directly into the target file, instead of copy pasting.

Example:

`dbt --quiet run-operation generate_model_yaml --args '{"model_name": "stg_jaffle_shop__orders"}' > models/staging/jaffle_shop/stg_jaffle_shop__orders.yml`

This would also enable further automation, i.e. generating model yaml for all files in a directory etc. 

Should resolve https://github.com/dbt-labs/dbt-codegen/issues/56 and https://github.com/dbt-labs/dbt-codegen/issues/71

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] Not applicable - I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
