### PR TITLE
FEATURE- Add logic in generate_source macro to generate nested …

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,3 +8,5 @@ target-path: "target"
 clean-targets: ["target", "dbt_packages"]
 macro-paths: ["macros"]
 log-path: "logs"
+
+profile: "astrafy"

--- a/macros/generate_source.sql
+++ b/macros/generate_source.sql
@@ -20,8 +20,8 @@
         {% set column_name = column.name %}
     {% endif %}
 
-    {% do model_yaml.append('         - name: ' ~ column_name | lower ) %}
-    {% do model_yaml.append('           description: "' ~ '"') %}
+    {% do model_yaml.append('          - name: ' ~ column_name | lower ) %}
+    {% do model_yaml.append('            description: "' ~ '"') %}
 
     {% if column.fields|length > 0 %}
         {% for child_column in column.fields %}

--- a/macros/generate_source.sql
+++ b/macros/generate_source.sql
@@ -22,7 +22,6 @@
 
     {% do model_yaml.append('         - name: ' ~ column_name | lower ) %}
     {% do model_yaml.append('           description: "' ~ '"') %}
-    {% do model_yaml.append('') %}
 
     {% if column.fields|length > 0 %}
         {% for child_column in column.fields %}

--- a/profiles.yml
+++ b/profiles.yml
@@ -1,0 +1,20 @@
+config:
+  partial_parse: true
+  use_colors: true
+  printer_width: 80
+  send_anonymous_usage_stats: false
+
+astrafy:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: oauth
+      project: internal-data-aaa
+      execution_project: astrafy-gke
+      schema: na
+      threads: 4
+      timeout_seconds: 300
+      location: EU
+      priority: interactive
+      retries: 1


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [X] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Currently the 'generate_source' macro does not support nested fields. The 'generate_model_yaml' has this logic and this pull requests adds this logic for nested fields to the 'generate_source' macro.
-->

## Checklist
- [X] I have verified that these changes work locally
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [] I have added an entry to CHANGELOG.md
