### PR TITLE
issue106/get_models helper macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Addition of the [create_base_models](macros/create_base_models.sql)
 This macro generates a series of terminal commands (appended w) bash script which creates a new file in your dbt project based off the results of the [generate_base_model](macros/generate_base_model.sql) macro. Therefore, instead of outputting in the terminal, it will create the file for you.
 - Add `include_data_types` flag to `generate_source` macro ([#76](https://github.com/dbt-labs/dbt-codegen/pull/76))
+- Add `get_models` macro in helper macros. This macro retrieves a list of models with specified prefix at the specified directory. It is designed to make creating yamls for multiple models easier.
 
 ## Fixes
 - Fix handling of nested `STRUCT` fields in BigQuery ([#98](https://github.com/dbt-labs/dbt-codegen/issues/98), [#105](https://github.com/dbt-labs/dbt-codegen/pull/105))

--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ schema.yml file.
 ) }}
 ```
 
+You can use the helper function codegen.get_models and specify a directory and/or prefix to get a list of all matching models, to be passed into model_names list.
+
+```
+{{ codegen.generate_model_yaml(
+    model_names= codegen.get_models(directory='marts','prefix='fct_')
+) }}
+```
+
 Alternatively, call the macro as an [operation](https://docs.getdbt.com/docs/using-operations):
 
 ```

--- a/integration_tests/tests/test_generate_model_yaml_multiple_models_using_get_model.sql
+++ b/integration_tests/tests/test_generate_model_yaml_multiple_models_using_get_model.sql
@@ -1,0 +1,21 @@
+{% set actual_model_yaml_prefix = codegen.generate_model_yaml(
+    model_names = codegen.get_models(prefix='child_')
+  )
+%}
+
+{% set expected_model_yaml_prefix %}
+version: 2
+
+models:
+  - name: child_model
+    description: ""
+    columns:
+      - name: col_a
+        description: ""
+
+      - name: col_b
+        description: ""
+
+{% endset %}
+
+{{ assert_equal (actual_model_yaml_prefix | trim, expected_model_yaml_prefix | trim) }}

--- a/macros/helpers/helpers.sql
+++ b/macros/helpers/helpers.sql
@@ -27,3 +27,34 @@
         {{ return(glob_dict) }}
     {% endif %}
 {% endmacro %}
+
+{# build a list of models looping through all models in the project #}
+{# filter by directory or prefix arguments, if provided #}
+{% macro get_models(directory=None, prefix=None) %}
+    {% set model_names=[] %}
+    {% set models = graph.nodes.values() | selectattr('resource_type', "equalto", 'model') %}
+    {% if directory and prefix %}
+        {% for model in models %}
+            {% set model_path = "/".join(model.path.split("/")[:-1]) %}
+            {% if model_path == directory and model.name.startswith(prefix) %}
+                {% do model_names.append(model.name) %}
+            {% endif %} 
+        {% endfor %}
+    {% elif directory %}
+        {% for model in models %}
+            {% set model_path = "/".join(model.path.split("/")[:-1]) %}
+            {% if model_path == directory %}
+                {% do model_names.append(model.name) %}
+            {% endif %}
+        {% endfor %}
+    {% elif prefix %}
+        {% for model in models if model.name.startswith(prefix) %}
+            {% do model_names.append(model.name) %}
+        {% endfor %}
+    {% else %}
+        {% for model in models %}
+            {% do model_names.append(model.name) %}
+        {% endfor %}
+    {% endif %}
+    {{ return(model_names) }}
+{% endmacro %}


### PR DESCRIPTION
resolves #

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Added a helper macro named "get_models" in the macros/helpers section. The macro is used to get a list of all models with a specified prefix, in a specified directory.

Example:
codegen.get_models(directory='marts', prefix='fct')

I mainly created this to make generate_model_yaml macro more powerful.

Example:
codegen.generate_model_yaml(
    model_names = codegen.get_models(directory='marts', prefix='fct')

This way we can generate yamls for any set of models in our project.
-->

## Checklist
- [x] This code is associated with an issue (https://github.com/dbt-labs/dbt-codegen/issues/106) which has been triaged and [accepted for development]
(https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
