### PR TITLE
Fix example operation code

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ schema.yml file.
 Alternatively, call the macro as an [operation](https://docs.getdbt.com/docs/using-operations):
 
 ```
-$ dbt run-operation generate_model_yaml --args '{"model_names": ["customers"]}'
+$ dbt run-operation generate_model_yaml --args '{"model_names": "customers"}'
 ```
 
 3. The YAML for a base model(s) will be logged to the command line


### PR DESCRIPTION
This is a:
- [ x] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
This is a minor fix to the docs for example code for `generate_model_yaml`. The existing example does not compile due to the square brackets around the sample model. Removing the brackets allows the operation to run.

## Checklist
- [x ] I have verified that these changes work locally
- [ x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
