### PR TITLE
Make `generate_source` macro return case-sensitive names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This macro generates a series of terminal commands (appended w) bash script whic
 
 ## Fixes
 - Fix handling of nested `STRUCT` fields in BigQuery ([#98](https://github.com/dbt-labs/dbt-codegen/issues/98), [#105](https://github.com/dbt-labs/dbt-codegen/pull/105))
+- Fix `generate_source` behavior of applying a lowercase function to all object names ([#112](https://github.com/dbt-labs/dbt-codegen/issues/112))
 
 ## Quality of life
 - Addition of the [base_model_creation](bash_scripts/base_model_creation.sh) bash script which allows users to input multiple tables as a list and generate a terminal command that will combine **all** [create_base_models](macros/create_base_models.sql) commands. This way, you can generate base models for all your sources at once.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ want to subselect from all available tables within a given schema.
 the database to your source definition
 * `include_schema` (optional, default=False): Whether you want to add
 the schema to your source definition
+* `case_sensitive_tables` (optional, default=False): Whether you want table names to be
+in lowercase, or to match the case in the source table
+* `case_sensitive_cols` (optional, default=False): Whether you want column names to be
+in lowercase, or to match the case in the source table
 
 ### Usage:
 1. Copy the macro into a statement tab in the dbt Cloud IDE, or into an analysis file, and compile your code

--- a/macros/generate_source.sql
+++ b/macros/generate_source.sql
@@ -15,7 +15,7 @@
 
 
 ---
-{% macro generate_source(schema_name, database_name=target.database, generate_columns=False, include_descriptions=False, include_data_types=False, table_pattern='%', exclude='', name=schema_name, table_names=None, include_database=False, include_schema=False) %}
+{% macro generate_source(schema_name, database_name=target.database, generate_columns=False, include_descriptions=False, include_data_types=False, table_pattern='%', exclude='', name=schema_name, table_names=None, include_database=False, include_schema=False, case_sensitive_tables=False, case_sensitive_cols=False) %}
 
 {% set sources_yaml=[] %}
 {% do sources_yaml.append('version: 2') %}

--- a/macros/generate_source.sql
+++ b/macros/generate_source.sql
@@ -44,7 +44,7 @@
 {% endif %}
 
 {% for table in tables %}
-    {% do sources_yaml.append('      - name: ' ~ table | lower ) %}
+    {% do sources_yaml.append('      - name: ' ~ (table if case_sensitive_tables else table | lower)) %}
     {% if include_descriptions %}
         {% do sources_yaml.append('        description: ""' ) %}
     {% endif %}
@@ -60,7 +60,7 @@
         {% set columns=adapter.get_columns_in_relation(table_relation) %}
 
         {% for column in columns %}
-            {% do sources_yaml.append('          - name: ' ~ column.name | lower ) %}
+            {% do sources_yaml.append('          - name: ' ~ (column.name if case_sensitive_cols else column.name | lower)) %}
             {% if include_data_types %}
                 {% do sources_yaml.append('            data_type: ' ~ (column.data_type | upper ) ) %}
             {% endif %}


### PR DESCRIPTION
resolves #112 

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
For organizations with strict standards around the letter case of their tables and columns. The existing behavior of the `generate_source` macro is that it returns all table and column names in lowercase. This makes it less useful for the previously mentioned organizations.

This adds the parameters `case_sensitive_tables` and `case_sensitive_cols` to the `generate_source` macro. Both default to `false` to preserve existing behavior.
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [ ] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
