### PR TITLE
Changelog for v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,26 @@ This macro generates a series of terminal commands (appended w) bash script whic
 - [@GSokol](https://github.com/GSokol) (#76)
 - [@linbug](https://github.com/linbug) (#120)
 
+# dbt-codegen v0.10.0
+
+## What's Changed
+* added comments to verbose regex in generate_model_import_ctes by @graciegoheen in https://github.com/dbt-labs/dbt-codegen/pull/93
+* Feature/hackathon model generator by @fivetran-joemarkiewicz in https://github.com/dbt-labs/dbt-codegen/pull/83
+* Suggestion to include packages.yml example in README.md  by @Maayan-s in https://github.com/dbt-labs/dbt-codegen/pull/77
+* Add include_data_types flag to generate_source macro by @GSokol in https://github.com/dbt-labs/dbt-codegen/pull/76
+* Expected result of nested struct in BigQuery by @dbeatty10 in https://github.com/dbt-labs/dbt-codegen/pull/105
+* issue106/get_models helper macro by @erkanncelen in https://github.com/dbt-labs/dbt-codegen/pull/115
+* Feat/generate sources add database and schema by @jeremyholtzman in https://github.com/dbt-labs/dbt-codegen/pull/124
+
+## New Contributors
+* @fivetran-joemarkiewicz made their first contribution in https://github.com/dbt-labs/dbt-codegen/pull/83
+* @Maayan-s made their first contribution in https://github.com/dbt-labs/dbt-codegen/pull/77
+* @GSokol made their first contribution in https://github.com/dbt-labs/dbt-codegen/pull/76
+* @erkanncelen made their first contribution in https://github.com/dbt-labs/dbt-codegen/pull/115
+* @jeremyholtzman made their first contribution in https://github.com/dbt-labs/dbt-codegen/pull/124
+
+**Full Changelog**: https://github.com/dbt-labs/dbt-codegen/compare/0.9.0...0.10.0
+
 # dbt-codegen v0.9.0
 
 # dbt-codegen v0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,3 @@
-<!--- Copy, paste, and uncomment the following headers as-needed for unreleased features
-# Unreleased
-## Breaking changes
-## New features
-- XXX ([#XXX](https://github.com/dbt-labs/dbt-codegen/issues/XXX), [#XXX](https://github.com/dbt-labs/dbt-codegen/pull/XXX))
-## Fixes
-## Quality of life
-## Under the hood
-## Contributors:
-- [@handle](https://github.com/handle) (#XXX)
---->
-
-# Unreleased
-
 # dbt-codegen v0.11.0
 
 ## 🚨 Breaking change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 # Unreleased
 
+# dbt-codegen v0.11.0
+
 ## 🚨 Breaking change
 
 `include_data_types` parameter added to `generate_model_yaml` and behavior changed for `generate_source`. Both default to `true`
@@ -31,26 +33,19 @@ dispatch:
     search_order: ['my_project', 'codegen']
 ```
 
+## What's Changed
+* GitHub Action to add/remove triage labels as-needed by @dbeatty10 in https://github.com/dbt-labs/dbt-codegen/pull/133
+* GitHub Action to close issues as stale as-needed by @dbeatty10 in https://github.com/dbt-labs/dbt-codegen/pull/134
+* Update README.md by @cohms in https://github.com/dbt-labs/dbt-codegen/pull/129
+* Remove hard-coded values for database and schema by @dbeatty10 in https://github.com/dbt-labs/dbt-codegen/pull/139
+* Instructions for the release process by @dbeatty10 in https://github.com/dbt-labs/dbt-codegen/pull/137
+* Add `include_data_types` argument to `generate_model_yaml` macro by @linbug in https://github.com/dbt-labs/dbt-codegen/pull/122
 
-## New features
-- Addition of the [create_base_models](macros/create_base_models.sql)
-This macro generates a series of terminal commands (appended w) bash script which creates a new file in your dbt project based off the results of the [generate_base_model](macros/generate_base_model.sql) macro. Therefore, instead of outputting in the terminal, it will create the file for you.
-- Add `include_data_types` flag to `generate_source` macro ([#76](https://github.com/dbt-labs/dbt-codegen/pull/76))
-- Add `get_models` macro in helper macros. This macro retrieves a list of models with specified prefix at the specified directory. It is designed to make creating yamls for multiple models easier.
-- Add `include_data_types` flag to `generate_model_yaml` macro ([#122](https://github.com/dbt-labs/dbt-codegen/pull/122))
-- Add optional arguments to include database and schema properties in `sources.yml` generated from `generate_source` ([#123](https://github.com/dbt-labs/dbt-codegen/issues/123))
+## New Contributors
+* @cohms made their first contribution in https://github.com/dbt-labs/dbt-codegen/pull/129
+* @linbug made their first contribution in https://github.com/dbt-labs/dbt-codegen/pull/122
 
-## Fixes
-- Fix handling of nested `STRUCT` fields in BigQuery ([#98](https://github.com/dbt-labs/dbt-codegen/issues/98), [#105](https://github.com/dbt-labs/dbt-codegen/pull/105))
-
-## Quality of life
-- Addition of the [base_model_creation](bash_scripts/base_model_creation.sh) bash script which allows users to input multiple tables as a list and generate a terminal command that will combine **all** [create_base_models](macros/create_base_models.sql) commands. This way, you can generate base models for all your sources at once.
-- Instructions for contributing ([#99](https://github.com/dbt-labs/dbt-codegen/issues/99), [#104](https://github.com/dbt-labs/dbt-codegen/pull/104))
-
-## Contributors:
-- [@fivetran-joemarkiewicz](https://github.com/fivetran-joemarkiewicz) (#83)
-- [@GSokol](https://github.com/GSokol) (#76)
-- [@linbug](https://github.com/linbug) (#120)
+**Full Changelog**: https://github.com/dbt-labs/dbt-codegen/compare/0.10.0...v0.10.0
 
 # dbt-codegen v0.10.0
 


### PR DESCRIPTION
Three things:
1. Changelog for dbt-codegen v0.10.0
1. Changelog for dbt-codegen v0.11.0
1. Use instructions in [RELEASE.md](https://github.com/dbt-labs/dbt-codegen/blob/main/RELEASE.md) to generate changelog instead of manuallly adding changelog entries