### PR TITLE
Add optional parameter to generate_base_models with a select *

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ model.
 * `leading_commas` (optional, default=False): Whether you want your commas to be leading (vs trailing).
 * `case_sensitive_cols ` (optional, default=False): Whether your source table has case sensitive column names. If true, keeps the case of the column names from the source.
 * `materialized` (optional, default=None): Set materialization style (e.g. table, view, incremental) inside of the model's `config` block. If not set, materialization style will be controlled by `dbt_project.yml`
+* `select_star` (optional, default=False): When enabled, the base model will not explicitly select specific columns but instead `select *` all columns available in the source.
 
 
 ### Usage:
@@ -139,7 +140,8 @@ model.
 {{ codegen.generate_base_model(
     source_name='raw_jaffle_shop',
     table_name='customers',
-    materialized='table'
+    materialized='table',
+    select_star=True
 ) }}
 ```
 

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -4,7 +4,8 @@
     table_name='codegen_integration_tests__data_source_table_case_sensitive',
     leading_commas=True,
     case_sensitive_cols=True,
-    materialized='table'
+    materialized='table',
+    select_star=False
   )
 %}
 

--- a/integration_tests/tests/test_generate_base_models_select_star.sql
+++ b/integration_tests/tests/test_generate_base_models_select_star.sql
@@ -1,0 +1,29 @@
+
+{% set actual_base_model = codegen.generate_base_model(
+    source_name='codegen_integration_tests__data_source_schema',
+    table_name='codegen_integration_tests__data_source_table',
+    select_star=True
+  )
+%}
+
+{% set expected_base_model %}
+
+with source as (
+
+    select * from {%raw%}{{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table') }}{%endraw%}
+
+),
+
+renamed as (
+
+    select
+        *
+
+    from source
+
+)
+
+select * from renamed
+{% endset %}
+
+{{ assert_equal (actual_base_model | trim, expected_base_model | trim) }}

--- a/macros/batch_generate_bases.sql
+++ b/macros/batch_generate_bases.sql
@@ -1,0 +1,23 @@
+{% macro batch_generate_bases(source_name, database_name, leading_commas=False, case_sensitive_cols=False, materialized=None, select_star=False) %}
+{%- set sources = graph.sources.values() -%}
+{%- set existing_node_list = (
+    sources |
+    selectattr('source_name', "equalto", source_name | lower) |
+    selectattr('database', "equalto", database_name | lower) |
+    list) 
+-%}
+
+{%- for node in existing_node_list -%}
+base_{{database_name}}__{{source_name}}_{{node.name}}.sql
+
+{{ codegen.generate_base_model(
+    'javascript', 
+    node.name, 
+    leading_commas, 
+    case_sensitive_cols, 
+    materialized, 
+    select_star) 
+}}
+{% endfor %}
+
+{% endmacro %}

--- a/macros/batch_generate_bases.sql
+++ b/macros/batch_generate_bases.sql
@@ -1,3 +1,5 @@
+--awk '/base_/{x=$0}{command = "tail -n+3 > " x; print | command }' batch-base-test.txt 
+
 {% macro batch_generate_bases(source_name, database_name, leading_commas=False, case_sensitive_cols=False, materialized=None, select_star=False) %}
 {%- set sources = graph.sources.values() -%}
 {%- set existing_node_list = (
@@ -11,7 +13,7 @@
 base_{{database_name}}__{{source_name}}_{{node.name}}.sql
 
 {{ codegen.generate_base_model(
-    'javascript', 
+    source_name, 
     node.name, 
     leading_commas, 
     case_sensitive_cols, 

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -1,4 +1,4 @@
-{% macro generate_base_model(source_name, table_name, leading_commas=False, case_sensitive_cols=False, materialized=None) %}
+{% macro generate_base_model(source_name, table_name, leading_commas=False, case_sensitive_cols=False, materialized=None, select_star=False) %}
 
 {%- set source_relation = source(source_name, table_name) -%}
 
@@ -19,14 +19,18 @@ with source as (
 renamed as (
 
     select
-        {%- if leading_commas -%}
-        {%- for column in column_names %}
-        {{", " if not loop.first}}{% if not case_sensitive_cols %}{{ column | lower }}{% elif target.type == "bigquery" %}{{ column }}{% else %}{{ "\"" ~ column ~ "\"" }}{% endif %}
-        {%- endfor %}
+        {%- if select_star -%}
+            {{" * "}}
         {%- else -%}
-        {%- for column in column_names %}
-        {% if not case_sensitive_cols %}{{ column | lower }}{% elif target.type == "bigquery" %}{{ column }}{% else %}{{ "\"" ~ column ~ "\"" }}{% endif %}{{"," if not loop.last}}
-        {%- endfor -%}
+            {%- if leading_commas -%}
+            {%- for column in column_names %}
+            {{", " if not loop.first}}{% if not case_sensitive_cols %}{{ column | lower }}{% elif target.type == "bigquery" %}{{ column }}{% else %}{{ "\"" ~ column ~ "\"" }}{% endif %}
+            {%- endfor %}
+            {%- else -%}
+            {%- for column in column_names %}
+            {% if not case_sensitive_cols %}{{ column | lower }}{% elif target.type == "bigquery" %}{{ column }}{% else %}{{ "\"" ~ column ~ "\"" }}{% endif %}{{"," if not loop.last}}
+            {%- endfor -%}
+            {%- endif %}
         {%- endif %}
 
     from source


### PR DESCRIPTION
resolves #

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Adds `select_star` parameter to `generate_base_model` to allow users to choose whether the base model explicitly includes column from the source or always includes all columns available from the source table. This can reduce base maintenance chore overhead especially when coupled with the `materialization='view'` parameter.

## Checklist
- [ ] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
