### PR TITLE
Read upstream descriptions from sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## New features
+
+* `generate_model_yaml` with `upstream_descriptions=True` now reads from upstream sources in addition to models. 
+
 # dbt-codegen v0.11.0
 
 ## 🚨 Breaking change

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ schema.yml file.
 
 ### Arguments:
 * `model_names` (required): The model(s) you wish to generate YAML for.
-* `upstream_descriptions` (optional, default=False): Whether you want to include descriptions for identical column names from upstream models.
+* `upstream_descriptions` (optional, default=False): Whether you want to include descriptions for identical column names from upstream models and sources.
 * `include_data_types` (optional, default=True): Whether you want to add data types to your model column definitions.
 
 ### Usage:

--- a/integration_tests/models/model_from_source.sql
+++ b/integration_tests/models/model_from_source.sql
@@ -1,0 +1,3 @@
+select
+    *
+from {{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table') }}

--- a/integration_tests/models/source.yml
+++ b/integration_tests/models/source.yml
@@ -4,4 +4,9 @@ sources:
   - name: codegen_integration_tests__data_source_schema
     tables:
       - name: codegen_integration_tests__data_source_table
+        columns:
+          - name: my_integer_col
+            description: My Integer Column
+          - name: my_bool_col
+            description: My Boolean Column
       - name: codegen_integration_tests__data_source_table_case_sensitive

--- a/integration_tests/tests/test_generate_model_yaml_upstream_source_descriptions.sql
+++ b/integration_tests/tests/test_generate_model_yaml_upstream_source_descriptions.sql
@@ -1,0 +1,23 @@
+{% set actual_model_yaml = codegen.generate_model_yaml(
+    model_names=['model_from_source'],
+    upstream_descriptions=True,
+    include_data_types=False
+  )
+%}
+
+{% set expected_model_yaml %}
+version: 2
+
+models:
+  - name: model_from_source
+    description: ""
+    columns:
+      - name: my_integer_col
+        description: "My Integer Column"
+
+      - name: my_bool_col
+        description: "My Boolean Column"
+
+{% endset %}
+
+{{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}

--- a/integration_tests/tests/test_helper_get_models.sql
+++ b/integration_tests/tests/test_helper_get_models.sql
@@ -7,6 +7,6 @@
 {% set actual_list = codegen.get_models(prefix='model_')|sort %}
 {% endif %}
 
-{% set expected_list = ['model_data_a', 'model_struct', 'model_without_any_ctes', 'model_without_import_ctes'] %}
+{% set expected_list = ['model_data_a', 'model_from_source', 'model_struct', 'model_without_any_ctes', 'model_without_import_ctes'] %}
 
 {{ assert_equal (actual_list, expected_list) }}


### PR DESCRIPTION
resolves #153 

This is a:
- [x] bug fix with no breaking changes

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

`generate_model_yaml` now reads upstream description from sources, as well as models.

## Checklist
- [ ] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
