### PR TITLE
Escape upstream descriptions in generate_model_yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Fixes
+- Column `description` fields are now correctly escaped in `generate_model_yaml` ([#142](https://github.com/dbt-labs/dbt-codegen/issues/142))
+
 # dbt-codegen v0.11.0
 
 ## 🚨 Breaking change

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
-name: 'codegen'
-version: '0.5.0'
+name: "codegen"
+version: "0.5.0"
 
 require-dbt-version: [">=1.1.0", "<2.0.0"]
 config-version: 2
@@ -8,3 +8,6 @@ target-path: "target"
 clean-targets: ["target", "dbt_packages"]
 macro-paths: ["macros"]
 log-path: "logs"
+
+models:
+  +bind: false

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,6 +8,3 @@ target-path: "target"
 clean-targets: ["target", "dbt_packages"]
 macro-paths: ["macros"]
 log-path: "logs"
-
-models:
-  +bind: false

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,8 +1,8 @@
-name: 'codegen_integration_tests'
-version: '1.0'
+name: "codegen_integration_tests"
+version: "1.0"
 config-version: 2
 
-profile: 'integration_tests'
+profile: "integration_tests"
 
 model-paths: ["models"]
 analysis-paths: ["analyses"]
@@ -12,8 +12,8 @@ macro-paths: ["macros"]
 
 target-path: "target"
 clean-targets:
-    - "target"
-    - "dbt_packages"
+  - "target"
+  - "dbt_packages"
 
 seeds:
   +schema: raw_data
@@ -21,3 +21,7 @@ seeds:
 
 vars:
   my_table_reference: table_c
+
+models:
+  +bind: false
+

--- a/integration_tests/macros/operations/create_source_table.sql
+++ b/integration_tests/macros/operations/create_source_table.sql
@@ -16,7 +16,7 @@ reset enable_case_sensitive_identifier;
 {% do adapter.create_schema(target_schema) %}
 
 {% set drop_table_sql %}
-drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table
+drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table cascade
 {% endset %}
 
 {{ run_query(drop_table_sql) }}
@@ -33,7 +33,7 @@ create table {{ target_schema }}.codegen_integration_tests__data_source_table as
 {{ run_query(create_table_sql) }}
 
 {% set drop_table_sql_case_sensitive %}
-drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive
+drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive cascade
 {% endset %}
 
 {{ run_query(drop_table_sql_case_sensitive) }}

--- a/integration_tests/macros/operations/create_source_table.sql
+++ b/integration_tests/macros/operations/create_source_table.sql
@@ -16,7 +16,7 @@ reset enable_case_sensitive_identifier;
 {% do adapter.create_schema(target_schema) %}
 
 {% set drop_table_sql %}
-drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table cascade
+drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table {% if target.type == "redshift" %}cascade{% endif %}
 {% endset %}
 
 {{ run_query(drop_table_sql) }}
@@ -33,7 +33,7 @@ create table {{ target_schema }}.codegen_integration_tests__data_source_table as
 {{ run_query(create_table_sql) }}
 
 {% set drop_table_sql_case_sensitive %}
-drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive cascade
+drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive {% if target.type == "redshift" %}cascade{% endif %}
 {% endset %}
 
 {{ run_query(drop_table_sql_case_sensitive) }}

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -4,4 +4,4 @@ models:
   - name: model_data_a
     columns:
       - name: col_a
-        description: description column a
+        description: 'description column "a"'

--- a/integration_tests/package-lock.yml
+++ b/integration_tests/package-lock.yml
@@ -1,0 +1,5 @@
+packages:
+- local: ../
+- package: dbt-labs/dbt_utils
+  version: 1.1.1
+sha1_hash: de2deba3d66ce03d8c02949013650cc9b94f6030

--- a/integration_tests/tests/test_generate_model_yaml_upstream_descriptions.sql
+++ b/integration_tests/tests/test_generate_model_yaml_upstream_descriptions.sql
@@ -13,7 +13,7 @@ models:
     description: ""
     columns:
       - name: col_a
-        description: "description column a"
+        description: "description column \"a\""
 
       - name: col_b
         description: ""

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -13,7 +13,7 @@
     {% if include_data_types %}
         {% do model_yaml.append('        data_type: ' ~ codegen.data_type_format_model(column)) %}
     {% endif %}
-    {% do model_yaml.append('        description: "' ~ column_desc_dict.get(column.name | lower,'') ~ '"') %}
+    {% do model_yaml.append('        description: ' ~ (column_desc_dict.get(column.name | lower,'') | tojson)) %}
     {% do model_yaml.append('') %}
 
     {% if column.fields|length > 0 %}


### PR DESCRIPTION
resolves #142 

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

JSON-escapes upstream descriptions before inserting them in the YAML in `generate_model_yaml`.

## Checklist
- [ ] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally
- [x] ~I have updated the README.md (if applicable)~
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
