### PR TITLE
Improve DX with `just`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dbt_packages/
 logs/
 env/
 integration_tests/profiles.yml
+
+.venv

--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ alias gmic := dbt-generate-model-import-ctes
 ##############################################################################
 
 ##############################################################################
-# Developer recipes for testing and debugging the justfile.
+# Developer recipes for configuration, testing, and debugging of the justfile.
 ##############################################################################
 
 # Verify the package manager logic is working.

--- a/justfile
+++ b/justfile
@@ -67,7 +67,7 @@ dbt-generate-source database schema:
 
 alias gso := dbt-generate-source
 
-# Generate the model sql for a table defined in your sources yml
+# Generate a sql model for a table defined in your sources YAML.
 dbt-generate-base-model source table:
     @{{dbt}} run-operation codegen.generate_base_model --args '{"source_name": "{{source}}", "table_name": "{{table}}"}'  > generated/stg_{{table}}.sql
     @awk '/with source as \(/{p=1} p' generated/stg_{{table}}.sql > temp && mv temp generated/stg_{{table}}.sql
@@ -75,7 +75,7 @@ dbt-generate-base-model source table:
 
 alias gbase := dbt-generate-base-model
 
-# Generate model yml with all columns from a model sql file.
+# Generate YAML config with all columns from a SQL model file.
 generated_default := 'generated'
 dbt-generate-model-yaml model_name generated_folder=generated_default:
     @if [ ! -d "{{generated_folder}}" ]; then \
@@ -87,7 +87,7 @@ dbt-generate-model-yaml model_name generated_folder=generated_default:
 
 alias gmy := dbt-generate-model-yaml
 
-# generate model yml with all columns for all sql files without accompanying yml files.
+# Generate YAML config for any unconfigured SQL models.
 # Optionally accepts a parameter for folder to search in.
 default_folder := 'models'
 dbt-generate-missing-yaml folder=default_folder:
@@ -103,7 +103,7 @@ dbt-generate-missing-yaml folder=default_folder:
 
 alias gmiss := dbt-generate-missing-yaml
 
-# Clean up model references in your sql files by generating 'import 'CTEs for models referenced.
+# Clean up model references in your SQL models by generating 'import CTEs' for all `{{ ref}}`s.
 dbt-generate-model-import-ctes model_name generated_folder=generated_default:
     @if [ ! -d "{{generated_folder}}" ]; then \
         mkdir -p {{generated_folder}}; \

--- a/justfile
+++ b/justfile
@@ -1,25 +1,75 @@
-# Running without a recipe will list all available recipes.
+##############################################################################
+#                                                      88  88
+#    88                            ,d                  88  88            ,d 
+#                                  88                  88  88            88
+#    88  88       88  ,adPPYba,  MM88MMM       ,adPPYb,88  88,dPPYba,  MM88MMM
+#    88  88       88  I8[    ""    88         a8"    `Y88  88P'    "8a   88
+#    88  88       88   `"Y8ba,     88         8b       88  88       d8   88
+#    88  "8a,   ,a88  aa    ]8I    88,        "8a,   ,d88  88b,   ,a8"   88,
+#    88   `"YbbdP'Y8  `"YbbdP"'    "Y888       `"8bbdP"Y8  8Y"Ybbd8"'    "Y888
+#   ,88
+# 888P"
+##############################################################################
+# Justfile created by @wjhrdy
+#
+# Contributors:
+# - @gwenwindflower
+##############################################################################
+# Configuration for the just task runner
+# You set the two variables below.
+#
+# `venv_name` is the name of the virtual environment to create. Defaults to '.venv'.
+# If you choose a different name make sure to add it to your .gitignore file.
+#
+# `pm` is the package manager to use. This can be one of ['pip', 'poetry', 'uv'].
+#
+# Details on each can be found at:
+# - pip: Python's default package manager https://pip.pypa.io/en/stable/
+# - poetry: A fully integrated Python development tool https://python-poetry.org/
+# - uv: An ultra-fast pip alternative with the same API as pip https://astral.sh/uv
+#
+# We default to pip as it is the most common package manager for Python, but this
+# Justfile was originally created with poetry in mind, as it lets you run commands
+# in a virtual environment without having to activate it first with `poetry run`.
+#
+# `just` runs each command in a fresh shell, so commands that rely on installed
+# dependencies like `dbt` need the virtual environment activated first, which is
+# why `poetry run` is so handy. For `pip` and `uv`, we activate the virtual 
+# environment before running these commands in the same shell. You can see
+# the logic and recipes for this at the end of the file in the 'Developer recipes'.
+#
+# Start of user configuration:
+##############################################################################
+venv_name := '.venv'
+pm := "pip"
+##############################################################################
+# End of user configuration.
+##############################################################################
+
+##############################################################################
+# User recipes.
+# These are the codegen commands you can run with `just`.
+# You can add more recipes in this section for your workflow.
+# If you want to share a recipe you create we welcome PRs to the 
+# `dbt-codgen` repo! -> https://github.com/dbt-labs/dbt-codegen
+#
+# Check out the just documentation here for more on writing your own recipes:
+# https://just.systems/
+##############################################################################
+
+# List all recipes.
 default:
   @just --list --list-prefix=" ✴︎ "
 
-venv_name := ".venv"
-
-venv:
-  [ -d {{venv_name}} ] || python3 -m venv {{venv_name}}
-
-dev-setup adapter: venv
-  ./{{venv_name}}/bin/python3 -m pip install --upgrade pip
-  ./{{venv_name}}/bin/python3 -m pip install --pre dbt-core dbt-{{adapter}}
-
 # Generate _sources.yml for all tables in a schema.
 dbt-generate-source database schema:
-    @dbt run-operation codegen.generate_source --args '{"schema_name": "{{schema}}", "database_name": "{{database}}"}'
+    @{{dbt}} run-operation codegen.generate_source --args '{"schema_name": "{{schema}}", "database_name": "{{database}}"}'
 
 alias gso := dbt-generate-source
 
 # Generate the model sql for a table defined in your sources yml
 dbt-generate-base-model source table:
-    @dbt run-operation codegen.generate_base_model --args '{"source_name": "{{source}}", "table_name": "{{table}}"}'  > generated/stg_{{table}}.sql
+    @{{dbt}} run-operation codegen.generate_base_model --args '{"source_name": "{{source}}", "table_name": "{{table}}"}'  > generated/stg_{{table}}.sql
     @awk '/with source as \(/{p=1} p' generated/stg_{{table}}.sql > temp && mv temp generated/stg_{{table}}.sql
     @echo "Model {{table}} generated in generated/stg_{{table}}.sql"
 
@@ -31,7 +81,7 @@ dbt-generate-model-yaml model_name generated_folder=generated_default:
     @if [ ! -d "{{generated_folder}}" ]; then \
         mkdir -p {{generated_folder}}; \
     fi
-    @dbt run-operation codegen.generate_model_yaml --args '{"model_names": ["{{model_name}}"]}' > /tmp/{{model_name}}.tmpyml
+    @{{dbt}} run-operation codegen.generate_model_yaml --args '{"model_names": ["{{model_name}}"]}' > /tmp/{{model_name}}.tmpyml
     @awk '/models:/{p=1} p' /tmp/{{model_name}}.tmpyml > /tmp/temp{{model_name}} && mv /tmp/temp{{model_name}} {{generated_folder}}/{{model_name}}.yml
     @echo "Model {{model_name}} generated in {{generated_folder}}/{{model_name}}.yml"
 
@@ -58,8 +108,74 @@ dbt-generate-model-import-ctes model_name generated_folder=generated_default:
     @if [ ! -d "{{generated_folder}}" ]; then \
         mkdir -p {{generated_folder}}; \
     fi
-    @dbt run-operation codegen.generate_model_import_ctes --args '{"model_name": "{{model_name}}"}' > /tmp/{{model_name}}.tmpsql
+    @{{dbt}} run-operation codegen.generate_model_import_ctes --args '{"model_name": "{{model_name}}"}' > /tmp/{{model_name}}.tmpsql
     @awk '/with .* as \($/{p=1} p' /tmp/{{model_name}}.tmpsql | sed 's/^.*with/with/' > /tmp/temp{{model_name}} && mv /tmp/temp{{model_name}} {{generated_folder}}/{{model_name}}.sql
     @echo "SQL {{model_name}} updated in {{generated_folder}}/{{model_name}}.sql"
 
 alias gmic := dbt-generate-model-import-ctes
+
+##############################################################################
+# End of user recipes.
+##############################################################################
+
+##############################################################################
+# Developer recipes for testing and debugging the justfile.
+##############################################################################
+
+# Verify the package manager logic is working.
+test-dbt-command:
+  @echo {{dbt}}
+
+##############################################################################
+# End of developer recipes.
+##############################################################################
+
+##############################################################################
+# Package manager recipes.
+# You should not edit this unless you're adding a new package manager.
+##############################################################################
+va := if pm == "pip" {
+    "source " + venv_name / "bin/activate &&"
+  }  else if pm == "uv" {
+    "source " + venv_name / "bin/activate &&"
+  } else if pm == "poetry" {
+    "poetry run "
+  } else {
+    error("Invalid package manager")
+  }
+
+dbt := va + " dbt"
+
+create_venv_label := "Creating virtual environment with " + pm + "..."
+create_venv := if pm == "pip" {
+    "python3 -m venv " + venv_name
+  }  else if pm == "uv" {
+    "uv venv " + venv_name
+  } else if pm == "poetry" {
+    "poetry shell"
+  } else {
+    error("Invalid package manager")
+  }
+
+deps_label := "Installing dependencies with " + pm + "..."
+deps := if pm == "pip" {
+    "pip install -r requirements.txt"
+  }  else if pm == "uv" {
+    "uv pip install -r requirements.txt"
+  } else if pm == "poetry" {
+    "poetry install"
+  } else {
+    error("Invalid package manager")
+  }
+
+venv:
+  @echo {{create_venv_label}}
+  @[[ -d {{venv_name}} ]] || {{create_venv}}
+
+deps: venv
+  @echo {{deps_label}}
+  @{{deps}}
+
+######################################################################
+# End of package manager recipes.
+######################################################################

--- a/justfile
+++ b/justfile
@@ -124,22 +124,15 @@ alias gmic := dbt-generate-model-import-ctes
 
 # Verify the package manager logic is working.
 test-dbt-command:
-  @echo {{dbt}}
+  @echo "{{dbt}}"
 
-##############################################################################
-# End of developer recipes.
-##############################################################################
-
-##############################################################################
-# Package manager recipes.
-# You should not edit this unless you're adding a new package manager.
-##############################################################################
+# Package manager logic.
 va := if pm == "pip" {
     "source " + venv_name / "bin/activate &&"
   }  else if pm == "uv" {
     "source " + venv_name / "bin/activate &&"
   } else if pm == "poetry" {
-    "poetry run "
+    "poetry run"
   } else {
     error("Invalid package manager")
   }
@@ -168,10 +161,12 @@ deps := if pm == "pip" {
     error("Invalid package manager")
   }
 
+# Create a virtual environment.
 venv:
   @echo {{create_venv_label}}
   @[[ -d {{venv_name}} ]] || {{create_venv}}
 
+# Install dependencies into a virtual environment.
 deps: venv
   @echo {{deps_label}}
   @{{deps}}

--- a/justfile
+++ b/justfile
@@ -10,9 +10,10 @@
 #   ,88
 # 888P"
 ##############################################################################
-# Justfile created by @wjhrdy
+# This Justfile was created and open sourced by @wjhrdy.
 #
 # Contributors:
+# - @wjhrdy
 # - @gwenwindflower
 ##############################################################################
 # Configuration for the just task runner

--- a/justfile
+++ b/justfile
@@ -1,0 +1,65 @@
+# Running without a recipe will list all available recipes.
+default:
+  @just --list --list-prefix=" ✴︎ "
+
+venv_name := ".venv"
+
+venv:
+  [ -d {{venv_name}} ] || python3 -m venv {{venv_name}}
+
+dev-setup adapter: venv
+  ./{{venv_name}}/bin/python3 -m pip install --upgrade pip
+  ./{{venv_name}}/bin/python3 -m pip install --pre dbt-core dbt-{{adapter}}
+
+# Generate _sources.yml for all tables in a schema.
+dbt-generate-source database schema:
+    @dbt run-operation codegen.generate_source --args '{"schema_name": "{{schema}}", "database_name": "{{database}}"}'
+
+alias gso := dbt-generate-source
+
+# Generate the model sql for a table defined in your sources yml
+dbt-generate-base-model source table:
+    @dbt run-operation codegen.generate_base_model --args '{"source_name": "{{source}}", "table_name": "{{table}}"}'  > generated/stg_{{table}}.sql
+    @awk '/with source as \(/{p=1} p' generated/stg_{{table}}.sql > temp && mv temp generated/stg_{{table}}.sql
+    @echo "Model {{table}} generated in generated/stg_{{table}}.sql"
+
+alias gbase := dbt-generate-base-model
+
+# Generate model yml with all columns from a model sql file.
+generated_default := 'generated'
+dbt-generate-model-yaml model_name generated_folder=generated_default:
+    @if [ ! -d "{{generated_folder}}" ]; then \
+        mkdir -p {{generated_folder}}; \
+    fi
+    @dbt run-operation codegen.generate_model_yaml --args '{"model_names": ["{{model_name}}"]}' > /tmp/{{model_name}}.tmpyml
+    @awk '/models:/{p=1} p' /tmp/{{model_name}}.tmpyml > /tmp/temp{{model_name}} && mv /tmp/temp{{model_name}} {{generated_folder}}/{{model_name}}.yml
+    @echo "Model {{model_name}} generated in {{generated_folder}}/{{model_name}}.yml"
+
+alias gmy := dbt-generate-model-yaml
+
+# generate model yml with all columns for all sql files without accompanying yml files.
+# Optionally accepts a parameter for folder to search in.
+default_folder := 'models'
+dbt-generate-missing-yaml folder=default_folder:
+    @for sql_file in $(find {{folder}} -type f -name '*.sql'); do \
+        yml_file=${sql_file%.sql}.yml; \
+        if [ ! -f $yml_file ]; then \
+            model_name=${sql_file##*/}; \
+            model_name=${model_name%.sql}; \
+            folder_name=$(dirname ${sql_file}); \
+            just dbt-generate-model-yaml $model_name $folder_name; \
+        fi; \
+    done
+
+alias gmiss := dbt-generate-missing-yaml
+
+# Clean up model references in your sql files by generating 'import 'CTEs for models referenced.
+dbt-generate-model-import-ctes model_name generated_folder=generated_default:
+    @if [ ! -d "{{generated_folder}}" ]; then \
+        mkdir -p {{generated_folder}}; \
+    fi
+    @dbt run-operation codegen.generate_model_import_ctes --args '{"model_name": "{{model_name}}"}' > /tmp/{{model_name}}.tmpsql
+    @awk '/with .* as \($/{p=1} p' /tmp/{{model_name}}.tmpsql | sed 's/^.*with/with/' > /tmp/temp{{model_name}} && mv /tmp/temp{{model_name}} {{generated_folder}}/{{model_name}}.sql
+    @echo "SQL {{model_name}} updated in {{generated_folder}}/{{model_name}}.sql"
+
+alias gmic := dbt-generate-model-import-ctes


### PR DESCRIPTION
resolves #144 

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
`codegen` is awesome, but the developer experience is not the best. Due to its aim of using dbt itself to template the code, and not comprising on any sketchy hacks to write files, you're left getting command line output that you need to copy and paste into files. Many people over the years (myself included) have wrapped codegen with shell scripts, Python scripts etc to solve for this, but largely these efforts have remained isolated and haven't made their way back into this repo.

Thanks to some excellent work and thinking from @wjhrdy we're aiming to change that, starting with adding a robust set of [`just`](https://just.systems/man/en/chapter_1.html) commands to the repo.

Using `just` we can wrap and chain the macros with all the power of shell scripts (and even [other scripting languages](https://just.systems/man/en/chapter_41.html)!)

## Checklist
- [x] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md