### PR TITLE
Case sensitive generate model yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ schema.yml file.
 - `model_names` (required): The model(s) you wish to generate YAML for.
 - `upstream_descriptions` (optional, default=False): Whether you want to include descriptions for identical column names from upstream models and sources.
 - `include_data_types` (optional, default=True): Whether you want to add data types to your model column definitions.
+- `case_sensitive_model` (optional, default=False): Whether you want model names to be
+  in lowercase
+- `case_sensitive_cols` (optional, default=False): Whether you want column names to be
+  in lowercase
 
 ### Usage:
 

--- a/integration_tests/models/Case_Sensitive_Child_Model.sql
+++ b/integration_tests/models/Case_Sensitive_Child_Model.sql
@@ -1,0 +1,3 @@
+select 
+    * 
+from {{ ref('Case_Sensitive_Model') }}

--- a/integration_tests/models/Case_Sensitive_Model.sql
+++ b/integration_tests/models/Case_Sensitive_Model.sql
@@ -1,0 +1,4 @@
+select 
+    col_a as col_A,
+    col_b as col_B
+from {{ ref('data__a_relation') }}

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -5,3 +5,7 @@ models:
     columns:
       - name: col_a
         description: 'description column "a"'
+  - name: Case_Sensitive_Model
+    columns:
+      - name: col_A
+        description: 'description column "a"'

--- a/integration_tests/tests/test_generate_model_yaml_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_model_yaml_case_sensitive.sql
@@ -1,0 +1,25 @@
+{% set actual_model_yaml = codegen.generate_model_yaml(
+    model_names=['Case_Sensitive_Model'],
+    case_sensitive_models=True,
+    case_sensitive_cols=True
+  )
+%}
+
+{% set expected_model_yaml %}
+version: 2
+
+models:
+  - name: Case_Sensitive_Model
+    description: ""
+    columns:
+      - name: col_A
+        data_type: {{ integer_type_value() }}
+        description: ""
+
+      - name: col_B
+        data_type: {{ text_type_value() }}
+        description: ""
+
+{% endset %}
+
+{{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}

--- a/integration_tests/tests/test_generate_model_yaml_case_sensitive_upstream_descriptions.sql
+++ b/integration_tests/tests/test_generate_model_yaml_case_sensitive_upstream_descriptions.sql
@@ -1,0 +1,25 @@
+{% set actual_model_yaml = codegen.generate_model_yaml(
+    model_names=['Case_Sensitive_Child_Model'],
+    upstream_descriptions=True,
+    include_data_types=False,
+    case_sensitive_models=True,
+    case_sensitive_cols=True
+  )
+%}
+
+{% set expected_model_yaml %}
+version: 2
+
+models:
+  - name: Case_Sensitive_Child_Model
+    description: ""
+    columns:
+      - name: col_A
+        description: "description column \"a\""
+
+      - name: col_B
+        description: ""
+
+{% endset %}
+
+{{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -14,7 +14,7 @@
     {% if include_data_types %}
         {% do model_yaml.append('        data_type: ' ~ codegen.data_type_format_model(column)) %}
     {% endif %}
-    {% do model_yaml.append('        description: ' ~ (column_desc_dict.get(column.name | lower,'') | tojson)) %}
+    {% do model_yaml.append('        description: ' ~ (column_desc_dict.get(column_name,'') | tojson)) %}
     {% do model_yaml.append('') %}
 
     {% if column.fields|length > 0 %}
@@ -48,7 +48,7 @@
 
             {% set relation=ref(model) %}
             {%- set columns = adapter.get_columns_in_relation(relation) -%}
-            {% set column_desc_dict =  codegen.build_dict_column_descriptions(model) if upstream_descriptions else {} %}
+            {% set column_desc_dict =  codegen.build_dict_column_descriptions(model, case_sensitive_cols) if upstream_descriptions else {} %}
 
             {% for column in columns %}
                 {% set model_yaml = codegen.generate_column_yaml(column, model_yaml, column_desc_dict, include_data_types, case_sensitive_cols=case_sensitive_cols) %}

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -1,15 +1,16 @@
-{% macro generate_column_yaml(column, model_yaml, column_desc_dict, include_data_types, parent_column_name="") %}
-  {{ return(adapter.dispatch('generate_column_yaml', 'codegen')(column, model_yaml, column_desc_dict, include_data_types, parent_column_name)) }}
+{% macro generate_column_yaml(column, model_yaml, column_desc_dict, include_data_types, parent_column_name="", case_sensitive_cols=False) %}
+  {{ return(adapter.dispatch('generate_column_yaml', 'codegen')(column, model_yaml, column_desc_dict, include_data_types, parent_column_name, case_sensitive_cols)) }}
 {% endmacro %}
 
-{% macro default__generate_column_yaml(column, model_yaml, column_desc_dict, include_data_types, parent_column_name) %}
+{% macro default__generate_column_yaml(column, model_yaml, column_desc_dict, include_data_types, parent_column_name, case_sensitive_cols) %}
     {% if parent_column_name %}
-        {% set column_name = parent_column_name ~ "." ~ column.name %}
+        {% set full_column_name = parent_column_name ~ "." ~ column.name %}
     {% else %}
-        {% set column_name = column.name %}
+        {% set full_column_name = column.name %}
     {% endif %}
+    {% set column_name = full_column_name if case_sensitive_cols else full_column_name | lower %}
 
-    {% do model_yaml.append('      - name: ' ~ column_name  | lower ) %}
+    {% do model_yaml.append('      - name: ' ~ column_name ) %}
     {% if include_data_types %}
         {% do model_yaml.append('        data_type: ' ~ codegen.data_type_format_model(column)) %}
     {% endif %}
@@ -18,17 +19,17 @@
 
     {% if column.fields|length > 0 %}
         {% for child_column in column.fields %}
-            {% set model_yaml = codegen.generate_column_yaml(child_column, model_yaml, column_desc_dict, include_data_types, parent_column_name=column_name) %}
+            {% set model_yaml = codegen.generate_column_yaml(child_column, model_yaml, column_desc_dict, include_data_types, parent_column_name=column_name, case_sensitive_cols=case_sensitive_cols) %}
         {% endfor %}
     {% endif %}
     {% do return(model_yaml) %}
 {% endmacro %}
 
-{% macro generate_model_yaml(model_names=[], upstream_descriptions=False, include_data_types=True) -%}
-  {{ return(adapter.dispatch('generate_model_yaml', 'codegen')(model_names, upstream_descriptions, include_data_types)) }}
+{% macro generate_model_yaml(model_names=[], upstream_descriptions=False, include_data_types=True, case_sensitive_models=False, case_sensitive_cols=False) -%}
+  {{ return(adapter.dispatch('generate_model_yaml', 'codegen')(model_names, upstream_descriptions, include_data_types, case_sensitive_models, case_sensitive_cols)) }}
 {%- endmacro %}
 
-{% macro default__generate_model_yaml(model_names, upstream_descriptions, include_data_types) %}
+{% macro default__generate_model_yaml(model_names, upstream_descriptions, include_data_types, case_sensitive_models, case_sensitive_cols) %}
 
     {% set model_yaml=[] %}
 
@@ -40,7 +41,8 @@
         {{ exceptions.raise_compiler_error("The `model_names` argument must always be a list, even if there is only one model.") }}
     {% else %}
         {% for model in model_names %}
-            {% do model_yaml.append('  - name: ' ~ model | lower) %}
+            {% set model_name = model if case_sensitive_models else model | lower %}
+            {% do model_yaml.append('  - name: ' ~ model_name) %}
             {% do model_yaml.append('    description: ""') %}
             {% do model_yaml.append('    columns:') %}
 
@@ -49,7 +51,7 @@
             {% set column_desc_dict =  codegen.build_dict_column_descriptions(model) if upstream_descriptions else {} %}
 
             {% for column in columns %}
-                {% set model_yaml = codegen.generate_column_yaml(column, model_yaml, column_desc_dict, include_data_types) %}
+                {% set model_yaml = codegen.generate_column_yaml(column, model_yaml, column_desc_dict, include_data_types, case_sensitive_cols=case_sensitive_cols) %}
             {% endfor %}
         {% endfor %}
     {% endif %}


### PR DESCRIPTION
resolves #188 

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Working with a database that has capitalised model and column names, the result of `generate_model_yaml.sql` doesn't match the database because generate_model_yaml lowers all names.
I added optional parameters to the macro to toggle this behaviour. Similar functionality has already been added to `generate_source.sql`. I see no reason why this shouldn't be supported for models.

## Checklist
- [ ] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
