### PR TITLE
Fix quoted identifiers in the `generate_base_model` macro for BigQuery

### DIFF
--- a/integration_tests/macros/operations/create_source_table.sql
+++ b/integration_tests/macros/operations/create_source_table.sql
@@ -48,8 +48,8 @@ set enable_case_sensitive_identifier to true;
 {% set create_table_sql_case_sensitive %}
 create table {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive as (
     select
-        1 as {% if target.type == "bigquery" %}My_Integer_Col{% else %}"My_Integer_Col"{% endif %},
-        true as {% if target.type == "bigquery" %}My_Bool_Col{% else %}"My_Bool_Col"{% endif %}
+        1 as {{ adapter.quote("My_Integer_Col") }},
+        true as {{ adapter.quote("My_Bool_Col") }}
 )
 {% endset %}
 

--- a/integration_tests/tests/test_generate_base_models_all_args.sql
+++ b/integration_tests/tests/test_generate_base_models_all_args.sql
@@ -20,8 +20,8 @@ with source as (
 renamed as (
 
     select
-        {% if target.type == "bigquery" %}My_Integer_Col{% else %}"My_Integer_Col"{% endif %}
-        , {% if target.type == "bigquery" %}My_Bool_Col{% else %}"My_Bool_Col"{% endif %}
+        {{ adapter.quote("My_Integer_Col") }}
+        , {{ adapter.quote("My_Bool_Col") }}
 
     from source
 

--- a/integration_tests/tests/test_generate_base_models_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_base_models_case_sensitive.sql
@@ -15,7 +15,6 @@ with source as (
 
 renamed as (
 
-    -- force failure for all adapters
     select
         {{ adapter.quote("My_Integer_Col") }},
         {{ adapter.quote("My_Bool_Col") }}

--- a/integration_tests/tests/test_generate_base_models_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_base_models_case_sensitive.sql
@@ -16,8 +16,8 @@ with source as (
 renamed as (
 
     select
-        {% if target.type == "bigquery" %}My_Integer_Col{% else %}"My_Integer_Col"{% endif %},
-        {% if target.type == "bigquery" %}My_Bool_Col{% else %}"My_Bool_Col"{% endif %}
+        {{ adapter.quote("My_Integer_Col") }},
+        {{ adapter.quote("My_Bool_Col") }}
 
     from source
 

--- a/integration_tests/tests/test_generate_base_models_case_sensitive.sql
+++ b/integration_tests/tests/test_generate_base_models_case_sensitive.sql
@@ -15,6 +15,7 @@ with source as (
 
 renamed as (
 
+    -- force failure for all adapters
     select
         {{ adapter.quote("My_Integer_Col") }},
         {{ adapter.quote("My_Bool_Col") }}

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -25,11 +25,11 @@ renamed as (
     select
         {%- if leading_commas -%}
         {%- for column in column_names %}
-        {{", " if not loop.first}}{% if not case_sensitive_cols %}{{ column | lower }}{% elif target.type == "bigquery" %}{{ column }}{% else %}{{ "\"" ~ column ~ "\"" }}{% endif %}
+        {{", " if not loop.first}}{% if not case_sensitive_cols %}{{ column | lower }}{% else %}{{ adapter.quote(column) }}{% endif %}
         {%- endfor %}
         {%- else -%}
         {%- for column in column_names %}
-        {% if not case_sensitive_cols %}{{ column | lower }}{% elif target.type == "bigquery" %}{{ column }}{% else %}{{ "\"" ~ column ~ "\"" }}{% endif %}{{"," if not loop.last}}
+        {% if not case_sensitive_cols %}{{ column | lower }}{% else %}{{ adapter.quote(column) }}{% endif %}{{"," if not loop.last}}
         {%- endfor -%}
         {%- endif %}
 


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-codegen/issues/205
resolves https://github.com/dbt-labs/dbt-codegen/issues/193

## Problem

There's some code that adds quoted identifiers for bigquery in a hard-coded fashion. It doesn't handle when a column name in BigQuery needs to be quoted such as a reserved keyword or a column that starts with a number.

## Solution

Use `adapter.quote` to create a case-sensitive quoted identifier for column names since it is designed precisely for this type of use-case.

## 🎩

From CI for BigQuery:

```
23:43:04  3 of 23 START test test_generate_base_models_case_sensitive .................... [RUN]


with source as (

    select * from {{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table_case_sensitive') }}

),

renamed as (

    select
        `My_Integer_Col`,
        `My_Bool_Col`

    from source

)

select * from renamed

23:43:05  3 of 23 PASS test_generate_base_models_case_sensitive .......................... [PASS in 0.92s]
```

## Checklist
- [x] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).