### PR TITLE
Try removing Redshift-specific logic for toggling case-sensitive identifiers

### DIFF
--- a/integration_tests/macros/operations/create_source_table.sql
+++ b/integration_tests/macros/operations/create_source_table.sql
@@ -1,12 +1,5 @@
 {% macro create_source_table() %}
 
-{% if target.type == "redshift" %} 
-{% set disable_case_sensitive %}
-reset enable_case_sensitive_identifier;
-{% endset %}
-{{ run_query(disable_case_sensitive) }}
-{% endif %}
-
 {% set target_schema=api.Relation.create(
     database=target.database,
     schema="codegen_integration_tests__data_source_schema"
@@ -37,13 +30,6 @@ drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_
 {% endset %}
 
 {{ run_query(drop_table_sql_case_sensitive) }}
-
-{% if target.type == "redshift" %} 
-{% set enable_case_sensitive %}
-set enable_case_sensitive_identifier to true;
-{% endset %}
-{{ run_query(enable_case_sensitive) }}
-{% endif %}
 
 {% set create_table_sql_case_sensitive %}
 create table {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive as (


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-codegen/issues/206

## Problem

We have hard-coded logic just for Redshift that toggles a setting to enable case-sensitive identifiers. This makes the code harder to read and maintain.

## Solution

1. Ensure that the Redshift cluster for running CI tests has `enable_case_sensitive_identifier` set to `true` (rather than the default of `false`).
2. Remove the prior logic that toggled this setting on an as-needed basis.

## Checklist
- [x] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 