### PR TITLE
Use the `cimg/postgres` Docker image created by CircleCI with continu…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     docker:
       - image: cimg/python:3.9.9
-      - image: circleci/postgres:9.6.5-alpine-ram
+      - image: cimg/postgres:9.6
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,8 @@ jobs:
     docker:
       - image: cimg/python:3.9.9
       - image: cimg/postgres:9.6
-
+        environment:
+          POSTGRES_USER: root
     steps:
       - checkout
 


### PR DESCRIPTION
resolves #210

## Problem

The `circleci/postgres` image we are using in CircleCI is legacy and has been [deprecated](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034):

https://github.com/dbt-labs/dbt-codegen/blob/696c9f01758d727f9c1a360fcbe5af7b5ab7fa1e/.circleci/config.yml#L7

## Solution

Use the `cimg/postgres` Docker image created by CircleCI with continuous integration builds in mind.

## Checklist
- [x] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).