### PR TITLE
Stop installing prereleases from PyPI in favor of stable releases only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - checkout
-      - run: pip install --pre dbt-core dbt-postgres
+      - run: pip install dbt-core dbt-postgres
       - run:
           name: "Run Tests - Postgres"
           command: |
@@ -41,7 +41,7 @@ jobs:
       - image: cimg/python:3.9
     steps:
       - checkout
-      - run: pip install --pre dbt-core dbt-redshift
+      - run: pip install dbt-core dbt-redshift
       - run:
           name: "Run Tests - Redshift"
           command: |
@@ -63,7 +63,7 @@ jobs:
       - image: cimg/python:3.9
     steps:
       - checkout
-      - run: pip install --pre dbt-core dbt-snowflake
+      - run: pip install dbt-core dbt-snowflake
       - run:
           name: "Run Tests - Snowflake"
           command: |
@@ -87,7 +87,7 @@ jobs:
       - image: cimg/python:3.9
     steps:
       - checkout
-      - run: pip install --pre dbt-core dbt-bigquery
+      - run: pip install dbt-core dbt-bigquery
       - run:
           name: Setup Environment Variables
           command: |

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ dev: ## Installs dbt-* packages in develop mode along with development dependenc
 	@\
 	echo "Install dbt-$(target)..."; \
 	python -m pip install --upgrade pip setuptools; \
-	python -m pip install --pre dbt-core "dbt-$(target)";
+	python -m pip install dbt-core "dbt-$(target)";
 
 .PHONY: setup-db
 setup-db: ## Setup Postgres database with docker-compose for system testing.

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -89,7 +89,7 @@ Next, install `dbt-core` (and its dependencies) with:
 ```shell
 make dev target=[postgres|redshift|...]
 # or
-python3 -m pip install --pre dbt-core dbt-[postgres|redshift|...]
+python3 -m pip install dbt-core dbt-[postgres|redshift|...]
 ```
 
 Or more specific:
@@ -97,11 +97,8 @@ Or more specific:
 ```shell
 make dev target=postgres
 # or
-python3 -m pip install --pre dbt-core dbt-postgres
+python3 -m pip install dbt-core dbt-postgres
 ```
-
-> [!NOTE]
-> The `--pre` flag tells pip to install the latest pre-release version of whatever you pass to install. This ensures you're always using the latest version of dbt, so if your code interacts with dbt in a way that causes issues or test failures, we'll know about it ahead of a release.
 
 Make sure to reload your virtual environment after installing the dependencies:
 


### PR DESCRIPTION
resolves #219

## Problem

We recently had a prerelease of a dbt dependency (`protobuf`) break the CI in this dbt package. Then CI won't pass until that prerelease is yanked or superseded. So we'd either need to bypass CI in that case, or be blocked until it is resolved by a third party.

## Solution

Remove installation of pre-releases in favor of only installing the latest stable releases.

## Checklist
- [x] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 