### PR TITLE
Upgrade to Python 3.11 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
 
   integration-postgres:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
       - image: cimg/postgres:9.6
         environment:
           POSTGRES_USER: root
@@ -38,7 +38,7 @@ jobs:
 
   integration-redshift:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - run: pip install dbt-core dbt-redshift
@@ -60,7 +60,7 @@ jobs:
 
   integration-snowflake:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - run: pip install dbt-core dbt-snowflake
@@ -84,7 +84,7 @@ jobs:
     environment:
       BIGQUERY_SERVICE_KEY_PATH: "/home/circleci/bigquery-service-key.json"
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - run: pip install dbt-core dbt-bigquery


### PR DESCRIPTION
resolves #221

## Problem

[Python 3.9 is EOL in 2025-10](https://devguide.python.org/versions/).

## Solution

Upgrade it to Python 3.11 because that is what the GitHub Actions CI is using currently.

## Checklist
- [x] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 