### PR TITLE
Base model creation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ This bash script when executed from your local IDE will create model files in yo
 2. Copy the macro into a statement tab into your local IDE, and run your code
 
 ```bash
-source dbt_packages/codegen/bash_scripts/base_model_creation.sh "source_name" ["this-table","that-table"]
+source dbt_packages/codegen/bash_scripts/base_model_creation.sh source_name table-1 table-2 table-3 ...
 ```
 
 ## generate_model_yaml ([source](macros/generate_model_yaml.sql))

--- a/bash_scripts/base_model_creation.sh
+++ b/bash_scripts/base_model_creation.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
-echo "" > models/stg_$1__$2.sql
+# Check if at least two arguments are provided (source_name and at least one table_name)
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <source_name> <table_name1> [table_name2 ... table_nameN]"
+  exit 1
+fi
 
-dbt --quiet run-operation codegen.generate_base_model --args '{"source_name": "'$1'", "table_name": "'$2'"}' | tail -n +3 >> models/stg_$1__$2.sql
+SOURCE_NAME=$1
+shift # Shift to leave only table names in "$@"
+
+for TABLE_NAME in "$@"; do
+  dbt --quiet run-operation codegen.generate_base_model --args '{"source_name": "'$SOURCE_NAME'", "table_name": "'$TABLE_NAME'"}' | tail -n +3 >> models/stg_${SOURCE_NAME}__${TABLE_NAME}.sql
+  echo "Generated model for table: $TABLE_NAME"
+done


### PR DESCRIPTION
resolves #

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Base model creation would not accept more than one table name. Altered base_model_creation.sh to iterate thru args and call generate_base_model macro for each one
## Checklist
- [ ] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
