### PR TITLE
Upgrade from Postgres 9 to 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   integration-postgres:
     docker:
       - image: cimg/python:3.11
-      - image: cimg/postgres:9.6
+      - image: cimg/postgres:17
         environment:
           POSTGRES_USER: root
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   integration-postgres:
     docker:
       - image: cimg/python:3.11
-      - image: cimg/postgres:17
+      - image: cimg/postgres:17.0
         environment:
           POSTGRES_USER: root
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   postgres:
-    image: cimg/postgres:17
+    image: cimg/postgres:17.0
     environment:
       - POSTGRES_USER=root
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   postgres:
-    image: cimg/postgres:9.6
+    image: cimg/postgres:17
     environment:
       - POSTGRES_USER=root
     ports:


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-codegen/issues/231

## Description & motivation

Use a more recent version of Postgres, specifically one that supports the `MERGE` statement which is used in some dbt incremental strategies. While not a strict requirement for dbt-codegen, it is still desirable to use a version of Postgres for CI that aligns with those we'd recommend for production.

## Checklist
- [x] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).