### PR TITLE
Trigger CI off `pull_request_target` so workflow runs in the context of the base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     push:
         branches:
             - main
-    pull_request:
+    pull_request_target:
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Same issue as https://github.com/dbt-labs/dbt-utils/issues/971

### Problem

PRs from forks will fail CI because the PR trigger is `pull_request` so they do not have access to teh repo vars that are needed since the workflow runs in the context of the fork.  

### Solution

Update to trigger off `pull_request_target` and the workflow runs in the context of the base branch (this repo).

Does not require a release since it only affect local CI

## Checklist
- [ ] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally
- [ ] ~~I have updated the README.md (if applicable)~~
- [ ] ~~I have added tests & descriptions to my models (and macros if applicable)~~
- [ ] ~~I have added an entry to CHANGELOG.md~~
