### PR TITLE
Remove "I have added an entry to CHANGELOG.md" from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,3 @@ Describe your changes, and why you're making them.
 - [ ] I have verified that these changes work locally
 - [ ] I have updated the README.md (if applicable)
 - [ ] I have added tests & descriptions to my models (and macros if applicable)
-- [ ] I have added an entry to CHANGELOG.md


### PR DESCRIPTION
resolves #238

This is a:
- [x] under the hood change

## Problem

We have a checklist item reminding contributors to manually update the changelog. But we have been using the "Generate release notes" button in GitHub in place of manual [changelog](https://github.com/dbt-labs/dbt-codegen/blob/main/CHANGELOG.md) entries. So any changelog entries that are merged are just overwritten during the release.

Also, we have a long checklist, which lowers its utility.

## Solution

- Remove "I have added an entry to CHANGELOG.md" from the PR template 
- Checklist is one item shorter

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 