### PR TITLE
Remove the PR checklist items related to the type of change

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,5 @@
 resolves #
 
-This is a:
-- [ ] documentation update
-- [ ] bug fix with no breaking changes
-- [ ] new functionality
-- [ ] a breaking change
-
-All pull requests from community contributors should target the `main` branch (default).
-
 ## Description & motivation
 <!---
 Describe your changes, and why you're making them.


### PR DESCRIPTION
resolves #241

## Problem

Our PR template is pretty long, which makes it onerous to use. It is also unnecessarily different from the PR templates of dbt-core, dbt-adapters, etc.

## Solution

We already use GitHub labels like `bug`, `enhancement`, and `documentation` on issues to indicate the type of change. Since we require associated issues for each PR, we can use those labels and remove the related checklist items from the PR template. This will make things quite a bit shorter and easier to read PR descriptions 😎

## Checklist
- [x] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [N/A] I have verified that these changes work locally
- [N/A] I have updated the README.md (if applicable)
- [N/A] I have added tests & descriptions to my models (and macros if applicable)
