### PR TITLE
Align the PR description with dbt-core, dbt-adapters, etc.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,18 @@
 resolves #
 
-## Description & motivation
+### Problem
+
 <!---
-Describe your changes, and why you're making them.
+  Describe the problem this PR is solving. What is the application state
+  before this PR is merged?
+-->
+
+### Solution
+
+<!---
+  Describe the way this PR solves the above problem. Add as much detail as you
+  can to help reviewers understand your changes. Include any alternatives and
+  tradeoffs you considered.
 -->
 
 ## Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ resolves #
 -->
 
 ## Checklist
-- [ ] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
+- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-codegen/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
 - [ ] I have verified that these changes work locally
 - [ ] I have updated the README.md (if applicable)
 - [ ] I have added tests & descriptions to my models (and macros if applicable)


### PR DESCRIPTION
resolves #242

## Problem

The PR template of dbt-codegen has a single section for the main body of the description:
- Description & motivation

But dbt-core, dbt-adapters, etc. have two sections:
- Problem
- Solution

The latter allows the contributor to separate the design decisions of the implementation from the problem that it is trying to solve. This makes it easier for the contributor to write the PR description. It also makes it easier for others to read (code reviewers, users, etc.)

## Solution

Adopt the standard established by [dbt-core](https://github.com/dbt-labs/dbt-core/blob/a677abd5e84bd8e5d6ed3cec0903345e226d9462/.github/pull_request_template.md), [dbt-adapters](https://github.com/dbt-labs/dbt-adapters/blob/a2292c8ec76e4c9f03869ad95817a2ad82dfb34b/.github/pull_request_template.md), etc in order to make it easier to read/write and also for those working across repos.

## Checklist
- [x] This code is associated with an issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-codegen/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [N/A] I have verified that these changes work locally
- [N/A] I have updated the README.md (if applicable)
- [N/A] I have added tests & descriptions to my models (and macros if applicable)
