### PR TITLE
Align the pull request template with `dbt-utils`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ resolves #
 
 ## Checklist
 - [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-codegen/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
-- [ ] I have verified that these changes work locally
+- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-codegen/blob/main/CONTRIBUTING.md) and understand what's expected of me
+- [ ] I have run this code in development and it appears to resolve the stated issue
+- [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the README.md (if applicable)
-- [ ] I have added tests & descriptions to my models (and macros if applicable)


### PR DESCRIPTION
resolves #245

### Problem

The pull request templates of [`dbt-codegen`](https://github.com/dbt-labs/dbt-codegen/blob/70b4ecb79f51e75c1947d344f87efce65cada470/.github/pull_request_template.md) and [`dbt-utils`](https://github.com/dbt-labs/dbt-utils/blob/5c9dc0d43265cb86c5f69954e6d739dc7a1974c3/.github/pull_request_template.md) differ slightly, but not in any meaningful way.

### Solution

Just copy-paste from `dbt-utils` and then do a search and replace of `dbt-utils` with `dbt-codegen`

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-codegen/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [N/A] I have verified that these changes work locally
- [N/A] I have updated the README.md (if applicable)
- [N/A] I have added tests & descriptions to my models (and macros if applicable)