### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @clrcrl @dbt-labs/dbt-package-owners
+* @dbt-labs/dbt-package-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @clrcrl
+* @clrcrl @dbt-labs/dbt-package-owners


### PR DESCRIPTION
This PR amends the CODEOWNERS and appends a global codeowner to act as a fallback owner.

If this repository is no longer in use and can be archived or deleted please let us know.

Please reach out to Security Engineering if you have any questions.