### PR TITLE
Lowercase column names by default

### DIFF
--- a/macros/generate_unit_test_template.sql
+++ b/macros/generate_unit_test_template.sql
@@ -29,7 +29,7 @@
             {%- set columns = adapter.get_columns_in_relation(ref(item_dict.alias)) -%}
         {%- endif -%}
         {%- for column in columns -%}
-            {{ input_columns_list.append(column.name) }}
+            {{ input_columns_list.append(column.name|lower) }}
         {%- endfor -%}
         {{ ns.input_columns_list.append(input_columns_list) }}
     {%- endfor -%}
@@ -40,7 +40,7 @@
         {%- set ns.expected_columns_list = [] -%}
         {%- set columns = adapter.get_columns_in_relation(ref(model_name)) -%}
         {%- for column in columns -%}
-            {{ ns.expected_columns_list.append(column.name) }}
+            {{ ns.expected_columns_list.append(column.name|lower) }}
         {%- endfor -%}
     {% endif %}
 


### PR DESCRIPTION
resolves #254

### Problem

Macros that generate unit tests are capitalizing non-quoted column names for Snowflake.

### Solution

Lowercase all column names by default.
Defer to https://github.com/dbt-labs/dbt-codegen/issues/255 to handle case-sensitive column names.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-codegen/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-codegen/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
