### PR TITLE
feat: add case sensitivity option for `generate_model_yaml` column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ schema.yml file.
 - `upstream_descriptions` (optional, default=False): Whether you want to include descriptions for identical column names from upstream models and sources.
 - `include_data_types` (optional, default=True): Whether you want to add data types to your model column definitions.
 - `case_sensitive_cols` (optional, default=False): Whether you want column names to be
-  in lowercase, or to match the case in the source table.
+  in lowercase, or to match the case in the model table.
 
 ### Usage:
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ schema.yml file.
 - `model_names` (required): The model(s) you wish to generate YAML for.
 - `upstream_descriptions` (optional, default=False): Whether you want to include descriptions for identical column names from upstream models and sources.
 - `include_data_types` (optional, default=True): Whether you want to add data types to your model column definitions.
+- `case_sensitive_cols` (optional, default=False): Whether you want column names to be
+  in lowercase, or to match the case in the source table.
 
 ### Usage:
 

--- a/integration_tests/seeds/data__a_relation_case_sensitive_columns.csv
+++ b/integration_tests/seeds/data__a_relation_case_sensitive_columns.csv
@@ -1,0 +1,3 @@
+col_A,col_B
+1,a
+2,b

--- a/integration_tests/tests/test_generate_model_yaml_case_sensitive_columns.sql
+++ b/integration_tests/tests/test_generate_model_yaml_case_sensitive_columns.sql
@@ -1,0 +1,24 @@
+{% set actual_model_yaml = codegen.generate_model_yaml(
+    model_names=['data__a_relation_case_sensitive_columns'],
+    case_sensitive_cols=True,
+  )
+%}
+
+{% set expected_model_yaml %}
+version: 2
+
+models:
+  - name: data__a_relation_case_sensitive_columns
+    description: ""
+    columns:
+      - name: col_A
+        data_type: {{ integer_type_value() }}
+        description: ""
+
+      - name: col_B
+        data_type: {{ text_type_value() }}
+        description: ""
+
+{% endset %}
+
+{{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}

--- a/integration_tests/tests/test_generate_source.sql
+++ b/integration_tests/tests/test_generate_source.sql
@@ -11,6 +11,7 @@ sources:
   - name: {{ raw_schema | trim | lower }}
     tables:
       - name: data__a_relation
+      - name: data__a_relation_case_sensitive_columns
       - name: data__b_relation
       - name: data__campaign_analytics
 {% endset %}

--- a/integration_tests/tests/test_generate_source_all_args.sql
+++ b/integration_tests/tests/test_generate_source_all_args.sql
@@ -40,6 +40,16 @@ sources:
             data_type: {{ text_type_value() }}
             description: ""
 
+      - name: data__a_relation_case_sensitive_columns
+        description: ""
+        columns:
+          - name: col_a
+            data_type: {{ integer_type_value() }}
+            description: ""
+          - name: col_b
+            data_type: {{ text_type_value() }}
+            description: ""
+
       - name: data__b_relation
         description: ""
         columns:

--- a/integration_tests/tests/test_generate_source_include_database_property.sql
+++ b/integration_tests/tests/test_generate_source_include_database_property.sql
@@ -11,6 +11,7 @@ sources:
     database: {{ target.database | trim | lower }}
     tables:
       - name: data__a_relation
+      - name: data__a_relation_case_sensitive_columns
       - name: data__b_relation
       - name: data__campaign_analytics
 {% endset %}

--- a/integration_tests/tests/test_generate_source_include_schema_property.sql
+++ b/integration_tests/tests/test_generate_source_include_schema_property.sql
@@ -11,6 +11,7 @@ sources:
     schema: {{ raw_schema | trim | lower }}
     tables:
       - name: data__a_relation
+      - name: data__a_relation_case_sensitive_columns
       - name: data__b_relation
       - name: data__campaign_analytics
 {% endset %}

--- a/integration_tests/tests/test_generate_source_table_descriptions.sql
+++ b/integration_tests/tests/test_generate_source_table_descriptions.sql
@@ -13,6 +13,8 @@ sources:
     tables:
       - name: data__a_relation
         description: ""
+      - name: data__a_relation_case_sensitive_columns
+        description: ""
       - name: data__b_relation
         description: ""
       - name: data__campaign_analytics

--- a/integration_tests/tests/test_generate_source_table_name.sql
+++ b/integration_tests/tests/test_generate_source_table_name.sql
@@ -12,6 +12,7 @@ sources:
     schema: {{ raw_schema | trim | lower }}
     tables:
       - name: data__a_relation
+      - name: data__a_relation_case_sensitive_columns
       - name: data__b_relation
       - name: data__campaign_analytics
 


### PR DESCRIPTION
resolves #

### Problem

Column name case matters in yaml files - for instance when enabling constraints on a model. With a sufficiently many columns, you start to wish for this option to exist...

This addresses https://github.com/dbt-labs/dbt-codegen/issues/175.

### Solution

This CL adds an optional parameter to the `generate_model_yaml` macro to switch case sensitivity when generating model column names.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-codegen/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-codegen/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
