### PR TITLE
Include Fusion in require-dbt-version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: "codegen"
 version: "0.5.0"
 
-require-dbt-version: [">=1.1.0", "<2.0.0"]
+require-dbt-version: [">=1.1.0", "<3.0.0"]
 config-version: 2
 
 target-path: "target"


### PR DESCRIPTION
Include Fusion in require-dbt-version range to make it clear that it is compatible