### PR TITLE
Update base_model_creation documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ This bash script when executed from your local IDE will create model files in yo
 ### Arguments:
 
 - `source_name` (required): The source you wish to generate base model SQL for.
-- `tables` (required): A list of all tables you want to generate the base models for.
+- `table_name` (required): A single table name for which you want to generate the base model.
 
 ### Usage:
 
@@ -244,7 +244,7 @@ This bash script when executed from your local IDE will create model files in yo
 2. Copy the macro into a statement tab into your local IDE, and run your code
 
 ```bash
-source dbt_packages/codegen/bash_scripts/base_model_creation.sh "source_name" ["this-table","that-table"]
+source dbt_packages/codegen/bash_scripts/base_model_creation.sh "source_name" "table_name"
 ```
 
 ## generate_model_yaml ([source](macros/generate_model_yaml.sql))


### PR DESCRIPTION
base_model_creation supports only a single table and does not handle a list of tables.

Resolves #

### Problem

Error in `base_model_creation` documentation in `README.md`.

`base_model_creation` accepts only one table as an argument, but the current `README.md` states that it receives a list of tables. It appears to have been copy-pasted from another part of the documentation.

I encountered this documentation error multiple times. It is confusing, so I decided to fix it.

This is essentially a cosmetic fix, so I skipped creating an issue.

### Solution

Update  `README.md` with accurate information.


<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-codegen/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-codegen/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
