### PR TITLE
Fix get_models silently returning no results on Windows

### DIFF
--- a/macros/helpers/helpers.sql
+++ b/macros/helpers/helpers.sql
@@ -38,21 +38,34 @@
     {% endif %}
 {% endmacro %}
 
+{# detect whether the project is running on Mac/Linux (forward slash) or Windows (backslash) #}
+{# by inspecting original_file_path values already present in the graph #}
+{# adapted from https://github.com/dbt-labs/pro-serv-dag-auditing #}
+{% macro is_os_mac_or_linux() %}
+    {% for val in graph.nodes.values() %}
+        {{ return("\\" not in val.get("original_file_path", "")) }}
+    {% endfor %}
+    {{ return(true) }}
+{% endmacro %}
+
 {# build a list of models looping through all models in the project #}
 {# filter by directory or prefix arguments, if provided #}
 {% macro get_models(directory=None, prefix=None) %}
     {% set model_names=[] %}
     {% set models = graph.nodes.values() | selectattr('resource_type', "equalto", 'model') %}
+    {% if directory %}
+        {% set sep = "/" if codegen.is_os_mac_or_linux() else "\\" %}
+    {% endif %}
     {% if directory and prefix %}
         {% for model in models %}
-            {% set model_path = "/".join(model.path.split("/")[:-1]) %}
+            {% set model_path = sep.join(model.path.split(sep)[:-1]) %}
             {% if model_path == directory and model.name.startswith(prefix) %}
                 {% do model_names.append(model.name) %}
             {% endif %}
         {% endfor %}
     {% elif directory %}
         {% for model in models %}
-            {% set model_path = "/".join(model.path.split("/")[:-1]) %}
+            {% set model_path = sep.join(model.path.split(sep)[:-1]) %}
             {% if model_path == directory %}
                 {% do model_names.append(model.name) %}
             {% endif %}


### PR DESCRIPTION
## Summary

`get_models(directory=...)` silently returns an empty list on Windows because `model.path` uses backslashes as path separators, but the macro hardcodes `"/"` in its `split`/`join` calls:

```jinja
{# before — broken on Windows #}
{% set model_path = "/".join(model.path.split("/")[:-1]) %}
```

On Windows, `model.path` looks like `staging\my_model.sql`. Splitting on `"/"` produces a single-element list, so `[:-1]` gives `[]` and `model_path` becomes `""` — never matching any directory the user passes. No error is raised; the macro just returns nothing.

This bug only affects calls that use the `directory` parameter. Calls with `prefix` only, or no arguments, are unaffected.

## Fix

Adds a new `is_os_mac_or_linux()` helper macro that detects the OS at runtime by checking whether backslashes appear in `original_file_path` values already present in the dbt graph — no Python `os` module or env vars needed. This pattern is adapted from [`dbt-labs/pro-serv-dag-auditing`](https://github.com/dbt-labs/pro-serv-dag-auditing).

`get_models` then uses the detected separator for both `split` and `join`:

```jinja
{# after — works on Windows and Mac/Linux #}
{% set sep = "/" if codegen.is_os_mac_or_linux() else "\\" %}
{% set model_path = sep.join(model.path.split(sep)[:-1]) %}
```