### PR TITLE
Fix typo: contirbute -> contribute in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,4 +438,4 @@ unit_tests:
 
 ## Contributing
 
-To contirbute code to this package, please follow the steps outlined in the `integration_tests` directory's [README](https://github.com/dbt-labs/dbt-codegen/blob/main/integration_tests/README.md) file.
+To contribute code to this package, please follow the steps outlined in the `integration_tests` directory's [README](https://github.com/dbt-labs/dbt-codegen/blob/main/integration_tests/README.md) file.


### PR DESCRIPTION
## Summary

Fixes a typo in the Contributing section of README.md: "contirbute" -> "contribute".

## Test plan

- [x] Changes are cosmetic/config only — no behavior change
- [x] Verified patterns exist before fixing