### PR TITLE
fix: quote shell variables to prevent injection

### DIFF
--- a/bash_scripts/base_model_creation.sh
+++ b/bash_scripts/base_model_creation.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-echo "" > models/stg_$1__$2.sql
+echo "" > models/stg_"$1"__"$2".sql
 
-dbt --quiet run-operation codegen.generate_base_model --args '{"source_name": "'$1'", "table_name": "'$2'"}' | tail -n +3 >> models/stg_$1__$2.sql
+dbt --quiet run-operation codegen.generate_base_model --args '{"source_name": "'"$1"'", "table_name": "'"$2"'"}' | tail -n +3 >> models/stg_"$1"__"$2".sql

--- a/run_test.sh
+++ b/run_test.sh
@@ -4,8 +4,8 @@ echo `pwd`
 cd integration_tests
 cp ci/sample.profiles.yml profiles.yml
 
-dbt --warn-error deps --target $1 || exit 1
-dbt --warn-error run-operation create_source_table --target $1 || exit 1
-dbt --warn-error seed --target $1 --full-refresh || exit 1
-dbt --warn-error run --target $1 || exit 1
-dbt --warn-error test --target $1 || exit 1
+dbt --warn-error deps --target "$1" || exit 1
+dbt --warn-error run-operation create_source_table --target "$1" || exit 1
+dbt --warn-error seed --target "$1" --full-refresh || exit 1
+dbt --warn-error run --target "$1" || exit 1
+dbt --warn-error test --target "$1" || exit 1


### PR DESCRIPTION
## Summary

- Quote all positional parameters (`$1`, `$2`) in `bash_scripts/base_model_creation.sh` and `run_test.sh` with double quotes
- Prevents shell injection when source names, table names, or target arguments contain spaces, glob characters, or shell metacharacters

## Details

`base_model_creation.sh` uses `$1` and `$2` unquoted in both filename construction and the `--args` JSON string passed to `dbt run-operation`. A malformed source or table name (e.g. containing `$(cmd)` or `; rm -rf /`) would be interpreted by the shell rather than treated as a literal string.

`run_test.sh` similarly passes `$1` unquoted to `--target`, which has the same class of vulnerability.

## Test plan

- [x] Verified the quoting preserves existing behavior for simple alphanumeric arguments
- [x] Confirmed the `--args` JSON structure remains valid with the quote-close-quote-open pattern (`'"$1"'`)